### PR TITLE
W' Balance history chart + Skiba model improvements

### DIFF
--- a/app/src/main/kotlin/io/github/climbintelligence/ClimbIntelligenceExtension.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/ClimbIntelligenceExtension.kt
@@ -34,6 +34,7 @@ import io.hammerhead.karooext.models.FitEffect
 import io.hammerhead.karooext.models.OnStreamState
 import io.hammerhead.karooext.models.RideState
 import io.hammerhead.karooext.models.StreamState
+import io.hammerhead.karooext.models.UserProfile
 import io.github.climbintelligence.engine.ClimbStatsTracker
 import io.github.climbintelligence.engine.WPrimeEngine
 import io.github.climbintelligence.engine.PacingCalculator
@@ -193,6 +194,19 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
                     preferencesRepository.detectionSettingsFlow.collect { settings ->
                         _climbDetector?.updateSettings(settings)
                     }
+                }
+
+                // Bridge Karoo's user-profile FTP into our preferences so the
+                // W' / pacing engines pick up rider-configured FTP without
+                // forcing the rider to type it into both Karoo and 7climb.
+                val userProfileConsumerId = karooSystem.addConsumer { profile: UserProfile ->
+                    serviceScope.launch {
+                        preferencesRepository.updateKarooFtp(profile.ftp)
+                    }
+                }
+                connectionJobs += serviceScope.launch {
+                    try { kotlinx.coroutines.awaitCancellation() }
+                    finally { karooSystem.removeConsumer(userProfileConsumerId) }
                 }
 
                 // Wire data flow: ClimbDataService -> WPrimeEngine, PacingCalculator, ClimbDetector

--- a/app/src/main/kotlin/io/github/climbintelligence/ClimbIntelligenceExtension.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/ClimbIntelligenceExtension.kt
@@ -20,6 +20,7 @@ import io.github.climbintelligence.datatypes.glance.ClimbProfileGlanceDataType
 import io.github.climbintelligence.datatypes.glance.NextSegmentGlanceDataType
 import io.github.climbintelligence.datatypes.glance.CompactClimbGlanceDataType
 import io.github.climbintelligence.datatypes.glance.ClimbStatsGlanceDataType
+import io.github.climbintelligence.datatypes.glance.WPrimeHistoryGlanceDataType
 import io.github.climbintelligence.datatypes.glance.RideMetricsGlanceDataType
 import io.github.climbintelligence.datatypes.glance.PowerZonesGlanceDataType
 import io.github.climbintelligence.datatypes.glance.MatchBurnGlanceDataType
@@ -430,7 +431,8 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
             RideMetricsGlanceDataType(this),
             PowerZonesGlanceDataType(this),
             MatchBurnGlanceDataType(this),
-            NextClimbGlanceDataType(this)
+            NextClimbGlanceDataType(this),
+            WPrimeHistoryGlanceDataType(this)
         )
     }
 

--- a/app/src/main/kotlin/io/github/climbintelligence/ClimbIntelligenceExtension.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/ClimbIntelligenceExtension.kt
@@ -196,12 +196,13 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
                     }
                 }
 
-                // Bridge Karoo's user-profile FTP into our preferences so the
-                // W' / pacing engines pick up rider-configured FTP without
-                // forcing the rider to type it into both Karoo and 7climb.
+                // Bridge the Karoo's rider profile into our preferences so the
+                // W' / pacing engines pick up FTP + weight without forcing
+                // the rider to maintain those values in two places.
                 val userProfileConsumerId = karooSystem.addConsumer { profile: UserProfile ->
                     serviceScope.launch {
                         preferencesRepository.updateKarooFtp(profile.ftp)
+                        preferencesRepository.updateKarooWeight(profile.weight.toDouble())
                     }
                 }
                 connectionJobs += serviceScope.launch {

--- a/app/src/main/kotlin/io/github/climbintelligence/data/PreferencesRepository.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/data/PreferencesRepository.kt
@@ -31,8 +31,9 @@ class PreferencesRepository(private val context: Context) {
         private val KEY_BIKE_WEIGHT = doublePreferencesKey("bike_weight")
         private val KEY_CP = intPreferencesKey("cp")
         private val KEY_MAX_POWER = intPreferencesKey("max_power")
-        private val KEY_USE_KAROO_FTP = booleanPreferencesKey("use_karoo_ftp")
+        private val KEY_USE_KAROO_PROFILE = booleanPreferencesKey("use_karoo_profile")
         private val KEY_KAROO_FTP = intPreferencesKey("karoo_ftp")
+        private val KEY_KAROO_WEIGHT = doublePreferencesKey("karoo_weight")
         private val KEY_USE_THREE_PARAM_MODEL = booleanPreferencesKey("use_three_param_model")
         private val KEY_PACING_MODE = stringPreferencesKey("pacing_mode")
 
@@ -79,8 +80,9 @@ class PreferencesRepository(private val context: Context) {
                 bikeWeight = prefs[KEY_BIKE_WEIGHT] ?: 8.0,
                 cp = prefs[KEY_CP] ?: 0,
                 maxPower = prefs[KEY_MAX_POWER] ?: 0,
-                useKarooFtp = prefs[KEY_USE_KAROO_FTP] ?: true,
+                useKarooProfile = prefs[KEY_USE_KAROO_PROFILE] ?: true,
                 karooFtp = prefs[KEY_KAROO_FTP] ?: 0,
+                karooWeight = prefs[KEY_KAROO_WEIGHT] ?: 0.0,
                 useThreeParamModel = prefs[KEY_USE_THREE_PARAM_MODEL] ?: false,
             )
         }
@@ -262,15 +264,19 @@ class PreferencesRepository(private val context: Context) {
         context.dataStore.edit { it[KEY_MAX_POWER] = maxPower.coerceIn(0, 2500) }
     }
 
-    suspend fun updateUseKarooFtp(use: Boolean) {
-        context.dataStore.edit { it[KEY_USE_KAROO_FTP] = use }
+    suspend fun updateUseKarooProfile(use: Boolean) {
+        context.dataStore.edit { it[KEY_USE_KAROO_PROFILE] = use }
     }
 
     /** Called from ClimbIntelligenceExtension when the Karoo's UserProfile
-     *  stream emits a new FTP value. Bypasses the rider-visible "manual FTP"
-     *  field, so flipping the Karoo's FTP doesn't overwrite their typed value. */
+     *  stream emits new values. Bypasses the rider-visible "manual" fields,
+     *  so flipping the Karoo's profile doesn't overwrite the typed values. */
     suspend fun updateKarooFtp(ftp: Int) {
         context.dataStore.edit { it[KEY_KAROO_FTP] = ftp.coerceIn(0, 600) }
+    }
+
+    suspend fun updateKarooWeight(weightKg: Double) {
+        context.dataStore.edit { it[KEY_KAROO_WEIGHT] = weightKg.coerceIn(0.0, 200.0) }
     }
 
     suspend fun updateUseThreeParamModel(use: Boolean) {

--- a/app/src/main/kotlin/io/github/climbintelligence/data/PreferencesRepository.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/data/PreferencesRepository.kt
@@ -41,6 +41,11 @@ class PreferencesRepository(private val context: Context) {
         private val KEY_ALERT_SOUND = booleanPreferencesKey("alert_sound")
         private val KEY_ALERT_COOLDOWN = intPreferencesKey("alert_cooldown")
         private val KEY_WPRIME_ALERT_THRESHOLD = intPreferencesKey("wprime_alert_threshold")
+        private val KEY_ALERT_WPRIME_DEFICIT = booleanPreferencesKey("alert_wprime_deficit")
+
+        // W' history chart settings (W'-history-chart feature)
+        private val KEY_WPRIME_CHART_WINDOW_MIN = intPreferencesKey("wprime_chart_window_min")
+        private val KEY_WPRIME_CHART_REDRAW_SEC = intPreferencesKey("wprime_chart_redraw_sec")
 
         // Detection settings
         private val KEY_DETECTION_SENSITIVITY = stringPreferencesKey("detection_sensitivity")
@@ -113,6 +118,28 @@ class PreferencesRepository(private val context: Context) {
 
     val wPrimeAlertThresholdFlow: Flow<Int> = context.dataStore.data
         .map { prefs -> prefs[KEY_WPRIME_ALERT_THRESHOLD] ?: 20 }
+        .distinctUntilChanged()
+
+    /** One-shot alert when W' crosses below 0% (DEFICIT). Default ON. */
+    val alertWPrimeDeficitFlow: Flow<Boolean> = context.dataStore.data
+        .map { prefs -> prefs[KEY_ALERT_WPRIME_DEFICIT] ?: true }
+        .distinctUntilChanged()
+
+    /**
+     * Visible window for the W' history chart, in minutes.
+     * 0 = full ride; 5–240 = rolling window. Default 0.
+     */
+    val wPrimeChartWindowMinutesFlow: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[KEY_WPRIME_CHART_WINDOW_MIN] ?: 0 }
+        .distinctUntilChanged()
+
+    /**
+     * Minimum interval between chart Bitmap redraws, in seconds. Samples
+     * still append at 1Hz; only the chart bitmap regen is throttled.
+     * Default 2, range 1–10.
+     */
+    val wPrimeChartRedrawSecondsFlow: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[KEY_WPRIME_CHART_REDRAW_SEC] ?: 2 }
         .distinctUntilChanged()
 
     // Detection settings
@@ -257,6 +284,24 @@ class PreferencesRepository(private val context: Context) {
 
     suspend fun updateWPrimeAlertThreshold(percent: Int) {
         context.dataStore.edit { it[KEY_WPRIME_ALERT_THRESHOLD] = percent.coerceIn(5, 50) }
+    }
+
+    suspend fun updateAlertWPrimeDeficit(enabled: Boolean) {
+        context.dataStore.edit { it[KEY_ALERT_WPRIME_DEFICIT] = enabled }
+    }
+
+    suspend fun updateWPrimeChartWindowMinutes(minutes: Int) {
+        // 0 = full ride; 5–240 = rolling window. Anything between 1 and 4 snaps to 5.
+        val clamped = when {
+            minutes <= 0 -> 0
+            minutes < 5  -> 5
+            else         -> minutes.coerceAtMost(240)
+        }
+        context.dataStore.edit { it[KEY_WPRIME_CHART_WINDOW_MIN] = clamped }
+    }
+
+    suspend fun updateWPrimeChartRedrawSeconds(seconds: Int) {
+        context.dataStore.edit { it[KEY_WPRIME_CHART_REDRAW_SEC] = seconds.coerceIn(1, 10) }
     }
 
     suspend fun updateDetectionSensitivity(sensitivity: DetectionSensitivity) {

--- a/app/src/main/kotlin/io/github/climbintelligence/data/PreferencesRepository.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/data/PreferencesRepository.kt
@@ -30,6 +30,10 @@ class PreferencesRepository(private val context: Context) {
         private val KEY_CRR = doublePreferencesKey("crr")
         private val KEY_BIKE_WEIGHT = doublePreferencesKey("bike_weight")
         private val KEY_CP = intPreferencesKey("cp")
+        private val KEY_MAX_POWER = intPreferencesKey("max_power")
+        private val KEY_USE_KAROO_FTP = booleanPreferencesKey("use_karoo_ftp")
+        private val KEY_KAROO_FTP = intPreferencesKey("karoo_ftp")
+        private val KEY_USE_THREE_PARAM_MODEL = booleanPreferencesKey("use_three_param_model")
         private val KEY_PACING_MODE = stringPreferencesKey("pacing_mode")
 
         // Alert settings
@@ -73,7 +77,11 @@ class PreferencesRepository(private val context: Context) {
                 cda = prefs[KEY_CDA] ?: 0.321,
                 crr = prefs[KEY_CRR] ?: 0.005,
                 bikeWeight = prefs[KEY_BIKE_WEIGHT] ?: 8.0,
-                cp = prefs[KEY_CP] ?: 0
+                cp = prefs[KEY_CP] ?: 0,
+                maxPower = prefs[KEY_MAX_POWER] ?: 0,
+                useKarooFtp = prefs[KEY_USE_KAROO_FTP] ?: true,
+                karooFtp = prefs[KEY_KAROO_FTP] ?: 0,
+                useThreeParamModel = prefs[KEY_USE_THREE_PARAM_MODEL] ?: false,
             )
         }
         .distinctUntilChanged()
@@ -248,6 +256,25 @@ class PreferencesRepository(private val context: Context) {
 
     suspend fun updateCp(cp: Int) {
         context.dataStore.edit { it[KEY_CP] = cp.coerceIn(0, 500) }
+    }
+
+    suspend fun updateMaxPower(maxPower: Int) {
+        context.dataStore.edit { it[KEY_MAX_POWER] = maxPower.coerceIn(0, 2500) }
+    }
+
+    suspend fun updateUseKarooFtp(use: Boolean) {
+        context.dataStore.edit { it[KEY_USE_KAROO_FTP] = use }
+    }
+
+    /** Called from ClimbIntelligenceExtension when the Karoo's UserProfile
+     *  stream emits a new FTP value. Bypasses the rider-visible "manual FTP"
+     *  field, so flipping the Karoo's FTP doesn't overwrite their typed value. */
+    suspend fun updateKarooFtp(ftp: Int) {
+        context.dataStore.edit { it[KEY_KAROO_FTP] = ftp.coerceIn(0, 600) }
+    }
+
+    suspend fun updateUseThreeParamModel(use: Boolean) {
+        context.dataStore.edit { it[KEY_USE_THREE_PARAM_MODEL] = use }
     }
 
     suspend fun updatePacingMode(mode: PacingMode) {

--- a/app/src/main/kotlin/io/github/climbintelligence/data/model/AthleteProfile.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/data/model/AthleteProfile.kt
@@ -16,21 +16,29 @@ data class AthleteProfile(
      *  W' engine reports Maximum Power Available (MPA) alongside the standard
      *  W' balance. 0 disables MPA reporting. */
     val maxPower: Int = 0,
-    /** When true, [effectiveFtp] reads from [karooFtp] (the Karoo OS rider
-     *  profile) instead of the locally-typed [ftp], so the rider doesn't
-     *  maintain FTP in two places. */
-    val useKarooFtp: Boolean = true,
+    /** When true, [effectiveFtp] and [effectiveWeight] read from the Karoo's
+     *  rider-profile values ([karooFtp], [karooWeight]) instead of the locally-
+     *  typed [ftp] and [weight]. Default ON — the Karoo's profile is the
+     *  single source of truth most riders already maintain. */
+    val useKarooProfile: Boolean = true,
     /** Last-seen FTP value from the Karoo's UserProfile stream. Updated by
      *  ClimbIntelligenceExtension on every UserProfile event. */
     val karooFtp: Int = 0,
+    /** Last-seen body-weight value (kg) from the Karoo's UserProfile stream.
+     *  Updated alongside [karooFtp] in the same UserProfile consumer. */
+    val karooWeight: Double = 0.0,
     /** Toggle Morton 3-parameter (Pmax-aware) model on top of the Skiba
      *  2-param defaults. Off by default — needs a configured maxPower. */
     val useThreeParamModel: Boolean = false,
 ) {
-    /** FTP actually used by engines — prefers Karoo's value when toggled. */
-    val effectiveFtp: Int get() = if (useKarooFtp && karooFtp > 0) karooFtp else ftp
+    /** FTP actually used by engines — prefers Karoo's value when [useKarooProfile]. */
+    val effectiveFtp: Int get() = if (useKarooProfile && karooFtp > 0) karooFtp else ftp
+
+    /** Body weight (kg) actually used by engines — prefers Karoo's value when [useKarooProfile]. */
+    val effectiveWeight: Double get() = if (useKarooProfile && karooWeight > 0.0) karooWeight else weight
+
     /** CP actually used by engines — prefers explicit cp, else 95% of effective FTP. */
     val effectiveCp: Int get() = if (cp > 0) cp else (effectiveFtp * 0.95).toInt()
-    val isConfigured: Boolean get() = effectiveFtp > 0 && weight > 0
-    val totalMass: Double get() = weight + bikeWeight
+    val isConfigured: Boolean get() = effectiveFtp > 0 && effectiveWeight > 0
+    val totalMass: Double get() = effectiveWeight + bikeWeight
 }

--- a/app/src/main/kotlin/io/github/climbintelligence/data/model/AthleteProfile.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/data/model/AthleteProfile.kt
@@ -10,9 +10,27 @@ data class AthleteProfile(
     val cda: Double = 0.321,
     val crr: Double = 0.005,
     val bikeWeight: Double = 8.0,
-    val cp: Int = 0
+    val cp: Int = 0,
+    /** Pmax — peak instantaneous power, in watts. Drives the Morton 3-parameter
+     *  critical-power model: when > 0 and [useThreeParamModel] is true, the
+     *  W' engine reports Maximum Power Available (MPA) alongside the standard
+     *  W' balance. 0 disables MPA reporting. */
+    val maxPower: Int = 0,
+    /** When true, [effectiveFtp] reads from [karooFtp] (the Karoo OS rider
+     *  profile) instead of the locally-typed [ftp], so the rider doesn't
+     *  maintain FTP in two places. */
+    val useKarooFtp: Boolean = true,
+    /** Last-seen FTP value from the Karoo's UserProfile stream. Updated by
+     *  ClimbIntelligenceExtension on every UserProfile event. */
+    val karooFtp: Int = 0,
+    /** Toggle Morton 3-parameter (Pmax-aware) model on top of the Skiba
+     *  2-param defaults. Off by default — needs a configured maxPower. */
+    val useThreeParamModel: Boolean = false,
 ) {
-    val effectiveCp: Int get() = if (cp > 0) cp else (ftp * 0.95).toInt()
-    val isConfigured: Boolean get() = ftp > 0 && weight > 0
+    /** FTP actually used by engines — prefers Karoo's value when toggled. */
+    val effectiveFtp: Int get() = if (useKarooFtp && karooFtp > 0) karooFtp else ftp
+    /** CP actually used by engines — prefers explicit cp, else 95% of effective FTP. */
+    val effectiveCp: Int get() = if (cp > 0) cp else (effectiveFtp * 0.95).toInt()
+    val isConfigured: Boolean get() = effectiveFtp > 0 && weight > 0
     val totalMass: Double get() = weight + bikeWeight
 }

--- a/app/src/main/kotlin/io/github/climbintelligence/data/model/WPrimeState.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/data/model/WPrimeState.kt
@@ -18,7 +18,12 @@ data class WPrimeState(
     val recoveryRate: Double = 0.0,
     val timeToEmpty: Long = -1L,
     val timeToFull: Long = -1L,
-    val status: WPrimeStatus = WPrimeStatus.FRESH
+    val status: WPrimeStatus = WPrimeStatus.FRESH,
+    /** Maximum Power Available right now (Morton 3-parameter model). 0 when
+     *  disabled (athlete profile has no maxPower / useThreeParamModel off).
+     *  MPA = Pmax − (Pmax − CP) × ((W'max − W'balance) / W'max)² — so at full
+     *  W' it equals Pmax, and decays quadratically toward CP as W' depletes. */
+    val mpa: Int = 0,
 ) {
     companion object {
         /**

--- a/app/src/main/kotlin/io/github/climbintelligence/data/model/WPrimeState.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/data/model/WPrimeState.kt
@@ -6,7 +6,8 @@ enum class WPrimeStatus {
     WORKING,    // 50-70%
     DEPLETING,  // 30-50%
     CRITICAL,   // 10-30%
-    EMPTY       // < 10%
+    EMPTY,      // 0-10%
+    DEFICIT     // < 0%  — model predicts depletion beyond W'max; signals W'max likely under-calibrated
 }
 
 data class WPrimeState(
@@ -20,16 +21,14 @@ data class WPrimeState(
     val status: WPrimeStatus = WPrimeStatus.FRESH
 ) {
     companion object {
+        /**
+         * Build a WPrimeState from a balance value. As of the W'-history-chart PR,
+         * balance is allowed to be negative (the Skiba model's signal that W'max is
+         * calibrated too low). Percentage is computed without saturation.
+         */
         fun fromBalance(balance: Double, maxBalance: Double): WPrimeState {
-            val pct = (balance / maxBalance * 100.0).coerceIn(0.0, 100.0)
-            val status = when {
-                pct > 90 -> WPrimeStatus.FRESH
-                pct > 70 -> WPrimeStatus.GOOD
-                pct > 50 -> WPrimeStatus.WORKING
-                pct > 30 -> WPrimeStatus.DEPLETING
-                pct > 10 -> WPrimeStatus.CRITICAL
-                else -> WPrimeStatus.EMPTY
-            }
+            val pct = if (maxBalance > 0) balance / maxBalance * 100.0 else 0.0
+            val status = statusForPercentage(pct)
             return WPrimeState(
                 balance = balance,
                 maxBalance = maxBalance,
@@ -37,5 +36,28 @@ data class WPrimeState(
                 status = status
             )
         }
+
+        fun statusForPercentage(pct: Double): WPrimeStatus = when {
+            pct > 90 -> WPrimeStatus.FRESH
+            pct > 70 -> WPrimeStatus.GOOD
+            pct > 50 -> WPrimeStatus.WORKING
+            pct > 30 -> WPrimeStatus.DEPLETING
+            pct > 10 -> WPrimeStatus.CRITICAL
+            pct >= 0 -> WPrimeStatus.EMPTY
+            else     -> WPrimeStatus.DEFICIT
+        }
     }
 }
+
+/**
+ * Per-tick snapshot of W' state for history tracking. Sized small (32 bytes per
+ * sample) so a 24h ring buffer at 1Hz fits in ~2.8 MB. Fields chosen to make
+ * future surge-evaluation analyzers self-sufficient — they shouldn't need to
+ * re-instrument the engine to read drawdown patterns.
+ */
+data class WPrimeSample(
+    val timestampMs: Long,
+    val balance: Double,
+    val percentage: Double,
+    val power: Int
+)

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/GlanceDataType.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/GlanceDataType.kt
@@ -15,6 +15,7 @@ import io.github.climbintelligence.data.model.PacingTarget
 import io.github.climbintelligence.data.model.RideMetrics
 import io.github.climbintelligence.data.model.WPrimeSample
 import io.github.climbintelligence.data.model.WPrimeState
+import io.github.climbintelligence.data.model.WPrimeStatus
 import io.github.climbintelligence.engine.PRComparison
 import io.github.climbintelligence.engine.TacticalAnalyzer
 import io.hammerhead.karooext.extension.DataTypeImpl
@@ -89,8 +90,36 @@ data class ClimbDisplayState(
             ),
             nextClimb = NextClimbInfo(
                 distanceToStart = 2300.0, etaSeconds = 500, hasNext = true
-            )
+            ),
+            wPrimeHistory = previewWPrimeHistory()
         )
+
+        /**
+         * Synthetic W' history for the data-field picker preview.
+         * 30 samples over 5 minutes shaped like intervals.icu's reference
+         * curve: smooth bleed → deficit dip → recovery. Lets the rider see
+         * what the chart looks like before adding it to a ride profile.
+         */
+        private fun previewWPrimeHistory(): List<WPrimeSample> {
+            val now = System.currentTimeMillis()
+            val wMax = 20000.0
+            return (0..29).map { i ->
+                val phase = i / 29.0
+                val pctOfMax = when {
+                    phase < 0.30 -> 1.0 - phase * 2.3                       //  100% → ~30%
+                    phase < 0.50 -> 0.3 - (phase - 0.30) * 2.5               //  ~30% → -20%
+                    phase < 0.70 -> -0.20 + (phase - 0.50) * 2.0             //  -20% → ~20%
+                    else         -> 0.20 + (phase - 0.70) * 1.5              //  ~20% → ~65%
+                }
+                val balance = wMax * pctOfMax
+                WPrimeSample(
+                    timestampMs = now - (29 - i) * 10_000L,                  // 10 s spacing
+                    balance = balance,
+                    percentage = pctOfMax * 100.0,
+                    power = if (pctOfMax > 0.3) 220 else if (pctOfMax > 0.0) 320 else 380
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/GlanceDataType.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/GlanceDataType.kt
@@ -13,6 +13,7 @@ import io.github.climbintelligence.data.model.MatchBurnState
 import io.github.climbintelligence.data.model.NextClimbInfo
 import io.github.climbintelligence.data.model.PacingTarget
 import io.github.climbintelligence.data.model.RideMetrics
+import io.github.climbintelligence.data.model.WPrimeSample
 import io.github.climbintelligence.data.model.WPrimeState
 import io.github.climbintelligence.engine.PRComparison
 import io.github.climbintelligence.engine.TacticalAnalyzer
@@ -44,7 +45,8 @@ data class ClimbDisplayState(
     val climbStats: ClimbStats = ClimbStats(),
     val rideMetrics: RideMetrics = RideMetrics(),
     val matchBurn: MatchBurnState = MatchBurnState(),
-    val nextClimb: NextClimbInfo = NextClimbInfo()
+    val nextClimb: NextClimbInfo = NextClimbInfo(),
+    val wPrimeHistory: List<WPrimeSample> = emptyList()
 ) {
     companion object {
         val PREVIEW = ClimbDisplayState(
@@ -203,7 +205,8 @@ abstract class GlanceDataType(
             climbStats = climbExtension.climbStatsTracker.state.value,
             rideMetrics = climbExtension.metricsEngine.state.value,
             matchBurn = climbExtension.matchBurnEngine.state.value,
-            nextClimb = climbExtension.climbDataService.nextClimb.value
+            nextClimb = climbExtension.climbDataService.nextClimb.value,
+            wPrimeHistory = climbExtension.wPrimeEngine.wPrimeHistory.value
         )
     }
 }

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/fit/ClimbFitRecording.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/fit/ClimbFitRecording.kt
@@ -16,6 +16,13 @@ object ClimbFitRecording {
     private const val UINT8: Short = 2
     private const val UINT16: Short = 132
     private const val SINT32: Short = 133
+    /**
+     * SINT8 base type id (FIT SDK base types: enum=0, sint8=1, uint8=2, ...).
+     * As of the W'-history-chart PR, W_Prime_Percent is recorded as SINT8 so
+     * the negative range (rider overdrawn past W'max) is preserved in the FIT
+     * file — required for honest post-ride analysis (intervals.icu et al).
+     */
+    private const val SINT8: Short = 1
 
     val wPrimeBalanceField = DeveloperField(
         fieldDefinitionNumber = 0,
@@ -26,7 +33,7 @@ object ClimbFitRecording {
 
     val wPrimePercentField = DeveloperField(
         fieldDefinitionNumber = 1,
-        fitBaseTypeId = UINT8,
+        fitBaseTypeId = SINT8,
         fieldName = "W_Prime_Percent",
         units = "percent"
     )
@@ -85,8 +92,11 @@ object ClimbFitRecording {
         matchCount: Int = 0
     ): WriteToRecordMesg {
         val values = mutableListOf(
+            // W_Prime_Balance: Float32 records the honest unclamped value (can be negative).
+            // W_Prime_Percent: Sint8 — saturate at the type's range, not at 0/100,
+            // so deficit (-X%) is preserved while extreme out-of-range values can't overflow.
             FieldValue(wPrimeBalanceField, wPrimeBalance),
-            FieldValue(wPrimePercentField, wPrimePercent.coerceIn(0.0, 100.0)),
+            FieldValue(wPrimePercentField, wPrimePercent.coerceIn(-128.0, 127.0)),
             FieldValue(pacingStatusField, pacingAdviceOrdinal.toDouble()),
             FieldValue(targetPowerField, targetPower.toDouble())
         )
@@ -115,7 +125,7 @@ object ClimbFitRecording {
         return WriteToSessionMesg(
             listOf(
                 FieldValue(wPrimeBalanceField, wPrimeBalance),
-                FieldValue(wPrimePercentField, wPrimePercent.coerceIn(0.0, 100.0))
+                FieldValue(wPrimePercentField, wPrimePercent.coerceIn(-128.0, 127.0))
             )
         )
     }

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/GlanceColors.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/GlanceColors.kt
@@ -29,6 +29,8 @@ object GlanceColors {
     val WPrimeDepleting = Color(0xFFFF9800)
     val WPrimeCritical = Color(0xFFF44336)
     val WPrimeEmpty = Color(0xFF9E9E9E)
+    /** DEFICIT — W' below 0%, model says rider is overdrawn (W'max likely under-calibrated). */
+    val WPrimeDeficit = Color(0xFF9C27B0)  // purple — distinct from existing palette
 
     // PR delta
     val Ahead = Color(0xFF4CAF50)
@@ -87,7 +89,8 @@ object GlanceColors {
         percentage > 50 -> WPrimeWorking
         percentage > 30 -> WPrimeDepleting
         percentage > 10 -> WPrimeCritical
-        else -> WPrimeEmpty
+        percentage >= 0 -> WPrimeEmpty
+        else            -> WPrimeDeficit
     }
 
     fun pacingColor(advice: PacingAdvice): Color = when (advice) {

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/GlanceComponents.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/GlanceComponents.kt
@@ -83,14 +83,15 @@ fun GlanceVerticalDivider(
 fun LabelText(
     text: String,
     modifier: GlanceModifier = GlanceModifier,
-    fontSize: Int = 12
+    fontSize: Int = 12,
+    color: Color = GlanceColors.Label
 ) {
     Text(
         text = text,
         modifier = modifier,
         style = TextStyle(
             fontSize = fontSize.sp,
-            color = ColorProvider(GlanceColors.Label)
+            color = ColorProvider(color)
         ),
         maxLines = 1
     )

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
@@ -60,7 +60,7 @@ object WPrimeChartRenderer {
     private const val AXIS_LABEL_TEXT_SIZE_PX = 13f
     private const val PILL_TEXT_SIZE_PX = 13f
     private const val FULL_LEFT_PAD = 28f        // room for kJ labels
-    private const val FULL_RIGHT_PAD = 32f       // room for percent labels
+    private const val FULL_RIGHT_PAD = 44f       // room for percent labels ("100%" at 13px would clip at 32)
     private const val FULL_BOTTOM_PAD = 14f      // room for time labels
     private const val FULL_TOP_PAD = 4f
     private const val MINI_PAD = 2f

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
@@ -44,6 +44,16 @@ sealed class ChartMode {
 
 object WPrimeChartRenderer {
 
+    /**
+     * Overrender factor. Glance scales bitmaps to fill the widget slot on
+     * the Karoo screen; bilinear upscaling softens text and lines, which is
+     * why other (Text-based) Glance fields look crisper than this chart.
+     * Rendering at this multiple of the caller's logical dimensions and
+     * letting Glance scale DOWN (a clean operation) closes the gap. The
+     * bitmap memory cost scales with the square: 280 × 160 × 3 × 3 × 4 B
+     * ≈ 1.5 MB, well within budget for a per-tick re-render.
+     */
+    private const val RENDER_SCALE = 3
     private const val FILL_ALPHA = 51            // ~20% alpha for fill area
     private const val LINE_STROKE_PX = 2.5f
     private const val ZERO_LINE_STROKE_PX = 1.0f
@@ -77,8 +87,11 @@ object WPrimeChartRenderer {
     ): Bitmap {
         val w = width.coerceAtLeast(1)
         val h = height.coerceAtLeast(1)
-        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        // Overrender at RENDER_SCALE so Glance's Image scaler downsamples
+        // rather than upsamples — crisp text + lines at the device's DPI.
+        val bitmap = Bitmap.createBitmap(w * RENDER_SCALE, h * RENDER_SCALE, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
+        canvas.scale(RENDER_SCALE.toFloat(), RENDER_SCALE.toFloat())
 
         if (samples.isEmpty() || wMax <= 0.0) {
             return bitmap // blank for empty input

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
@@ -1,0 +1,381 @@
+package io.github.climbintelligence.datatypes.glance
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.DashPathEffect
+import android.graphics.Paint
+import android.graphics.Path
+import androidx.compose.ui.graphics.toArgb
+import io.github.climbintelligence.data.model.WPrimeSample
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Off-screen Canvas chart renderer for the W' balance history field.
+ *
+ * Glance widgets cannot draw smooth curves with their composable primitives
+ * (Box/Row/Column). The accepted Glance pattern for non-primitive graphics is
+ * to render to a Bitmap off-screen, then wrap it in androidx.glance.Image
+ * with an ImageProvider. This object encapsulates that.
+ *
+ * Rendering rules (matches the intervals.icu reference):
+ *   - Single-color line ABOVE the zero baseline: WPrimeFresh (green).
+ *   - Single-color line BELOW the zero baseline: WPrimeDeficit (purple).
+ *     This is the "reserve depth" — the model's signal that W'max is
+ *     calibrated too low.
+ *   - Fill area between the line and the zero baseline at ~20% alpha,
+ *     colored to match its side.
+ *   - Dashed zero reference line straight across the plot.
+ *   - FullDualAxis mode: kJ labels on the LEFT axis, percent labels on
+ *     the RIGHT axis. Single line plotted once; two axis-label sets at
+ *     the chart edges. Time-axis labels (start / mid / now) along the
+ *     bottom. Current-value pill anchored to the right edge of the line.
+ *
+ * Pure object: same inputs always produce a byte-identical Bitmap. Caller
+ * is responsible for trimming `samples` to the visible window before
+ * calling (the renderer plots whatever is passed in).
+ */
+sealed class ChartMode {
+    object Sparkline : ChartMode()        // line + fill only, no axes, no labels
+    object MiniWithCurrent : ChartMode()  // line + fill + current value pill (right edge)
+    object FullDualAxis : ChartMode()     // full chart: dual Y-axes, time axis, current pill
+    object Vertical : ChartMode()         // rotated 90° for NARROW slots
+}
+
+object WPrimeChartRenderer {
+
+    private const val FILL_ALPHA = 51            // ~20% alpha for fill area
+    private const val LINE_STROKE_PX = 2.5f
+    private const val ZERO_LINE_STROKE_PX = 1.0f
+    private const val AXIS_LABEL_TEXT_SIZE_PX = 11f
+    private const val PILL_TEXT_SIZE_PX = 13f
+    private const val FULL_LEFT_PAD = 28f        // room for kJ labels
+    private const val FULL_RIGHT_PAD = 32f       // room for percent labels
+    private const val FULL_BOTTOM_PAD = 14f      // room for time labels
+    private const val FULL_TOP_PAD = 4f
+    private const val MINI_PAD = 2f
+    private const val PILL_RIGHT_PAD = 4f
+    private const val PILL_HEIGHT_PX = 18f
+
+    /**
+     * Render the chart for the given sample window.
+     *
+     * @param samples ordered by timestampMs ascending; may be empty
+     * @param width target Bitmap width in pixels
+     * @param height target Bitmap height in pixels
+     * @param mode layout mode determining axes / labels / current-value pill
+     * @param wMax athlete's W' max in joules — used to compute percent axis
+     *             and to size the positive plot area even when no positive
+     *             samples are present
+     */
+    fun renderChart(
+        samples: List<WPrimeSample>,
+        width: Int,
+        height: Int,
+        mode: ChartMode,
+        wMax: Double
+    ): Bitmap {
+        val w = width.coerceAtLeast(1)
+        val h = height.coerceAtLeast(1)
+        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        if (samples.isEmpty() || wMax <= 0.0) {
+            return bitmap // blank for empty input
+        }
+
+        when (mode) {
+            is ChartMode.Vertical -> drawVertical(canvas, w, h, samples, wMax)
+            else -> drawHorizontal(canvas, w, h, samples, wMax, mode)
+        }
+
+        return bitmap
+    }
+
+    // ─── horizontal modes (Sparkline / MiniWithCurrent / FullDualAxis) ───
+
+    private fun drawHorizontal(
+        canvas: Canvas,
+        width: Int,
+        height: Int,
+        samples: List<WPrimeSample>,
+        wMax: Double,
+        mode: ChartMode
+    ) {
+        val pad = layoutPadding(mode)
+        val plotLeft = pad.left
+        val plotTop = pad.top
+        val plotRight = width - pad.right
+        val plotBottom = height - pad.bottom
+        if (plotRight <= plotLeft || plotBottom <= plotTop) return
+
+        val (yMin, yMax) = computeYRange(samples, wMax)
+        val plotW = (plotRight - plotLeft).toFloat()
+        val plotH = (plotBottom - plotTop).toFloat()
+
+        fun xPx(index: Int): Float = if (samples.size > 1) {
+            plotLeft + plotW * index / (samples.size - 1).toFloat()
+        } else {
+            plotLeft + plotW / 2f
+        }
+        fun yPx(balance: Double): Float {
+            val frac = (balance - yMin) / (yMax - yMin)
+            return (plotBottom - frac * plotH).toFloat()
+        }
+        val yZero = yPx(0.0).coerceIn(plotTop.toFloat(), plotBottom.toFloat())
+
+        drawFills(canvas, samples, ::xPx, ::yPx, yZero, plotLeft.toFloat(), plotRight.toFloat())
+        drawZeroLine(canvas, plotLeft.toFloat(), plotRight.toFloat(), yZero)
+        drawLine(canvas, samples, ::xPx, ::yPx, yZero)
+
+        if (mode is ChartMode.MiniWithCurrent) {
+            // Pill only on Mini sizes — FullDualAxis conveys current via the
+            // dual axes themselves; an extra pill would crowd the right-axis labels.
+            drawCurrentPill(canvas, samples.last(), plotRight.toFloat(), plotTop.toFloat(), plotBottom.toFloat())
+        }
+        if (mode is ChartMode.FullDualAxis) {
+            drawDualAxes(canvas, width, height, plotLeft.toFloat(), plotRight.toFloat(),
+                plotTop.toFloat(), plotBottom.toFloat(), yMin, yMax, wMax, samples)
+        }
+    }
+
+    // ─── vertical mode (rotated 90°) ───────────────────────────────────────
+
+    private fun drawVertical(
+        canvas: Canvas,
+        width: Int,
+        height: Int,
+        samples: List<WPrimeSample>,
+        wMax: Double
+    ) {
+        // Rotate so the time axis runs vertically. Swap effective dimensions.
+        canvas.save()
+        canvas.rotate(-90f, width / 2f, height / 2f)
+        // After rotation, the canvas drawable area is (height × width) — call the
+        // horizontal sparkline renderer with swapped dimensions.
+        drawHorizontal(canvas, height, width, samples, wMax, ChartMode.Sparkline)
+        canvas.restore()
+    }
+
+    // ─── primitives ───────────────────────────────────────────────────────
+
+    private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)
+
+    private fun layoutPadding(mode: ChartMode): Padding = when (mode) {
+        ChartMode.Sparkline -> Padding(MINI_PAD.toInt(), MINI_PAD.toInt(), MINI_PAD.toInt(), MINI_PAD.toInt())
+        ChartMode.MiniWithCurrent -> Padding(MINI_PAD.toInt(), MINI_PAD.toInt(), (MINI_PAD + 36f).toInt(), MINI_PAD.toInt())
+        ChartMode.FullDualAxis -> Padding(FULL_LEFT_PAD.toInt(), FULL_TOP_PAD.toInt(), FULL_RIGHT_PAD.toInt(), FULL_BOTTOM_PAD.toInt())
+        ChartMode.Vertical -> Padding(MINI_PAD.toInt(), MINI_PAD.toInt(), MINI_PAD.toInt(), MINI_PAD.toInt())
+    }
+
+    /**
+     * Compute Y range so 0 is always visible and the positive half always shows
+     * at least a fraction of W'max even when no samples are positive (gives the
+     * deficit case visual context).
+     */
+    private fun computeYRange(samples: List<WPrimeSample>, wMax: Double): Pair<Double, Double> {
+        val minSample = samples.minOf { it.balance }
+        val maxSample = samples.maxOf { it.balance }
+        // Show at least 20% of wMax above zero so positive headroom is visible
+        val yMax = max(maxSample, wMax * 0.2)
+        // Show at least 10% of wMax below zero so the zero crossing is visible
+        // even on a sustained-positive ride
+        val yMin = min(minSample, -wMax * 0.1)
+        return yMin to yMax
+    }
+
+    private fun drawFills(
+        canvas: Canvas,
+        samples: List<WPrimeSample>,
+        xPx: (Int) -> Float,
+        yPx: (Double) -> Float,
+        yZero: Float,
+        plotLeft: Float,
+        plotRight: Float
+    ) {
+        // Build a path that traces the line and closes down to the zero
+        // baseline. We then clip to above-zero / below-zero regions and fill
+        // each in its respective color at 20% alpha.
+        val fillPath = Path()
+        fillPath.moveTo(xPx(0), yZero)
+        for (i in samples.indices) {
+            fillPath.lineTo(xPx(i), yPx(samples[i].balance))
+        }
+        fillPath.lineTo(xPx(samples.lastIndex), yZero)
+        fillPath.close()
+
+        val greenFill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = GlanceColors.WPrimeFresh.toArgb()
+            alpha = FILL_ALPHA
+            style = Paint.Style.FILL
+        }
+        val purpleFill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = GlanceColors.WPrimeDeficit.toArgb()
+            alpha = FILL_ALPHA
+            style = Paint.Style.FILL
+        }
+
+        // Fill above-zero region (green)
+        canvas.save()
+        canvas.clipRect(plotLeft, 0f, plotRight, yZero)
+        canvas.drawPath(fillPath, greenFill)
+        canvas.restore()
+
+        // Fill below-zero region (purple)
+        canvas.save()
+        canvas.clipRect(plotLeft, yZero, plotRight, Float.MAX_VALUE)
+        canvas.drawPath(fillPath, purpleFill)
+        canvas.restore()
+    }
+
+    private fun drawZeroLine(canvas: Canvas, plotLeft: Float, plotRight: Float, yZero: Float) {
+        val zeroPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = GlanceColors.Separator.toArgb()
+            strokeWidth = ZERO_LINE_STROKE_PX
+            style = Paint.Style.STROKE
+            pathEffect = DashPathEffect(floatArrayOf(4f, 4f), 0f)
+        }
+        canvas.drawLine(plotLeft, yZero, plotRight, yZero, zeroPaint)
+    }
+
+    private fun drawLine(
+        canvas: Canvas,
+        samples: List<WPrimeSample>,
+        xPx: (Int) -> Float,
+        yPx: (Double) -> Float,
+        yZero: Float
+    ) {
+        // Build the line path once, stroke it twice with different clips so
+        // the above-zero portion is green and the below-zero portion is purple.
+        val linePath = Path()
+        linePath.moveTo(xPx(0), yPx(samples[0].balance))
+        for (i in 1 until samples.size) {
+            linePath.lineTo(xPx(i), yPx(samples[i].balance))
+        }
+
+        val greenLine = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = GlanceColors.WPrimeFresh.toArgb()
+            strokeWidth = LINE_STROKE_PX
+            style = Paint.Style.STROKE
+            strokeCap = Paint.Cap.ROUND
+            strokeJoin = Paint.Join.ROUND
+        }
+        val purpleLine = Paint(greenLine).apply {
+            color = GlanceColors.WPrimeDeficit.toArgb()
+        }
+
+        canvas.save()
+        canvas.clipRect(0f, 0f, Float.MAX_VALUE, yZero)
+        canvas.drawPath(linePath, greenLine)
+        canvas.restore()
+
+        canvas.save()
+        canvas.clipRect(0f, yZero, Float.MAX_VALUE, Float.MAX_VALUE)
+        canvas.drawPath(linePath, purpleLine)
+        canvas.restore()
+    }
+
+    private fun drawCurrentPill(
+        canvas: Canvas,
+        last: WPrimeSample,
+        plotRight: Float,
+        plotTop: Float,
+        plotBottom: Float
+    ) {
+        val text = "%.1f kJ".format(last.balance / 1000.0)
+        val color = if (last.balance >= 0)
+            GlanceColors.WPrimeFresh.toArgb()
+        else
+            GlanceColors.WPrimeDeficit.toArgb()
+
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = color
+            textSize = PILL_TEXT_SIZE_PX
+            textAlign = Paint.Align.RIGHT
+            isFakeBoldText = true
+        }
+
+        // Anchor pill text to the right edge of the plot, vertically centered
+        val centerY = (plotTop + plotBottom) / 2f
+        val baselineY = centerY - (textPaint.descent() + textPaint.ascent()) / 2f
+        canvas.drawText(text, plotRight + PILL_RIGHT_PAD * 6, baselineY, textPaint)
+    }
+
+    private fun drawDualAxes(
+        canvas: Canvas,
+        width: Int,
+        height: Int,
+        plotLeft: Float,
+        plotRight: Float,
+        plotTop: Float,
+        plotBottom: Float,
+        yMin: Double,
+        yMax: Double,
+        wMax: Double,
+        samples: List<WPrimeSample>
+    ) {
+        val labelPaintLeft = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = GlanceColors.Label.toArgb()
+            textSize = AXIS_LABEL_TEXT_SIZE_PX
+            textAlign = Paint.Align.RIGHT
+        }
+        val labelPaintRight = Paint(labelPaintLeft).apply { textAlign = Paint.Align.LEFT }
+        val labelPaintCenter = Paint(labelPaintLeft).apply { textAlign = Paint.Align.CENTER }
+
+        // ─── Y-axis labels: kJ on LEFT, percent on RIGHT ───
+        // Top label
+        val topLabelY = plotTop + AXIS_LABEL_TEXT_SIZE_PX
+        canvas.drawText("%.1f".format(yMax / 1000.0), plotLeft - 2f, topLabelY, labelPaintLeft)
+        canvas.drawText("%.0f%%".format(yMax / wMax * 100.0), plotRight + 2f, topLabelY, labelPaintRight)
+
+        // Zero baseline label
+        val yZero = plotBottom - ((0.0 - yMin) / (yMax - yMin) * (plotBottom - plotTop)).toFloat()
+        if (yZero in (plotTop + AXIS_LABEL_TEXT_SIZE_PX)..(plotBottom - AXIS_LABEL_TEXT_SIZE_PX)) {
+            canvas.drawText("0", plotLeft - 2f, yZero + AXIS_LABEL_TEXT_SIZE_PX / 2.5f, labelPaintLeft)
+            canvas.drawText("0%", plotRight + 2f, yZero + AXIS_LABEL_TEXT_SIZE_PX / 2.5f, labelPaintRight)
+        }
+
+        // Bottom label
+        val bottomLabelY = plotBottom - 1f
+        canvas.drawText("%.1f".format(yMin / 1000.0), plotLeft - 2f, bottomLabelY, labelPaintLeft)
+        canvas.drawText("%.0f%%".format(yMin / wMax * 100.0), plotRight + 2f, bottomLabelY, labelPaintRight)
+
+        // Axis unit hints — small letters below the top label
+        val hintPaint = Paint(labelPaintLeft).apply { textSize = AXIS_LABEL_TEXT_SIZE_PX - 1f; alpha = 180 }
+        canvas.drawText("kJ", plotLeft - 2f, topLabelY + AXIS_LABEL_TEXT_SIZE_PX, hintPaint)
+        val hintRightPaint = Paint(hintPaint).apply { textAlign = Paint.Align.LEFT }
+        canvas.drawText("%", plotRight + 2f, topLabelY + AXIS_LABEL_TEXT_SIZE_PX, hintRightPaint)
+
+        // ─── Time axis: start / mid / end labels ───
+        if (samples.size >= 2) {
+            val t0 = samples.first().timestampMs
+            val t1 = samples.last().timestampMs
+            val tMid = (t0 + t1) / 2
+            val totalSec = (t1 - t0) / 1000L
+            val timeBaselineY = (height - 1).toFloat()
+
+            val timePaintLeft = Paint(labelPaintLeft).apply { textAlign = Paint.Align.LEFT }
+            val timePaintCenter = Paint(labelPaintCenter)
+            val timePaintRight = Paint(labelPaintLeft) // already RIGHT-aligned
+
+            canvas.drawText(formatRideTime(0L, totalSec), plotLeft, timeBaselineY, timePaintLeft)
+            canvas.drawText(formatRideTime((tMid - t0) / 1000L, totalSec),
+                (plotLeft + plotRight) / 2f, timeBaselineY, timePaintCenter)
+            canvas.drawText(formatRideTime(totalSec, totalSec),
+                plotRight, timeBaselineY, timePaintRight)
+        }
+    }
+
+    private fun formatRideTime(seconds: Long, totalSec: Long): String {
+        // Use HH:MM:SS if the total ride exceeds 1h; MM:SS otherwise.
+        return if (totalSec >= 3600) {
+            val h = seconds / 3600
+            val m = (seconds % 3600) / 60
+            "%d:%02d".format(h, m)
+        } else {
+            val m = seconds / 60
+            val s = seconds % 60
+            "%d:%02d".format(m, s)
+        }
+    }
+}

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
@@ -57,7 +57,7 @@ object WPrimeChartRenderer {
     private const val FILL_ALPHA = 51            // ~20% alpha for fill area
     private const val LINE_STROKE_PX = 2.5f
     private const val ZERO_LINE_STROKE_PX = 1.0f
-    private const val AXIS_LABEL_TEXT_SIZE_PX = 11f
+    private const val AXIS_LABEL_TEXT_SIZE_PX = 13f
     private const val PILL_TEXT_SIZE_PX = 13f
     private const val FULL_LEFT_PAD = 28f        // room for kJ labels
     private const val FULL_RIGHT_PAD = 32f       // room for percent labels
@@ -353,11 +353,12 @@ object WPrimeChartRenderer {
         canvas.drawText("%.1f".format(yMin / 1000.0), plotLeft - 2f, bottomLabelY, labelPaintLeft)
         canvas.drawText("%.0f%%".format(yMin / wMax * 100.0), plotRight + 2f, bottomLabelY, labelPaintRight)
 
-        // Axis unit hints — small letters below the top label
+        // Left-axis unit hint — values on the left are pure numbers, so the
+        // 'kJ' hint clarifies them. The right axis labels already carry the
+        // '%' suffix, so no hint there (was duplicating information and
+        // looked like a stacked label).
         val hintPaint = Paint(labelPaintLeft).apply { textSize = AXIS_LABEL_TEXT_SIZE_PX - 1f; alpha = 180 }
         canvas.drawText("kJ", plotLeft - 2f, topLabelY + AXIS_LABEL_TEXT_SIZE_PX, hintPaint)
-        val hintRightPaint = Paint(hintPaint).apply { textAlign = Paint.Align.LEFT }
-        canvas.drawText("%", plotRight + 2f, topLabelY + AXIS_LABEL_TEXT_SIZE_PX, hintRightPaint)
 
         // ─── Time axis: start / mid / end labels ───
         if (samples.size >= 2) {

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeChartRenderer.kt
@@ -182,18 +182,21 @@ object WPrimeChartRenderer {
     }
 
     /**
-     * Compute Y range so 0 is always visible and the positive half always shows
-     * at least a fraction of W'max even when no samples are positive (gives the
-     * deficit case visual context).
+     * Compute Y range so 0 is always visible and the visible vertical extent
+     * matches the data — no imaginary negative headroom on positive-only rides.
+     *
+     *   - yMax: at least 20 % of wMax above zero so a deep-deficit ride still
+     *     shows positive headroom for visual context.
+     *   - yMin: 0 when no sample is negative (curve uses full plot height,
+     *     no `-10 %` label for data that never existed). When any sample IS
+     *     negative, expand to `-10 % of wMax` below zero so deficit values
+     *     get visible headroom under them.
      */
     private fun computeYRange(samples: List<WPrimeSample>, wMax: Double): Pair<Double, Double> {
         val minSample = samples.minOf { it.balance }
         val maxSample = samples.maxOf { it.balance }
-        // Show at least 20% of wMax above zero so positive headroom is visible
         val yMax = max(maxSample, wMax * 0.2)
-        // Show at least 10% of wMax below zero so the zero crossing is visible
-        // even on a sustained-positive ride
-        val yMin = min(minSample, -wMax * 0.1)
+        val yMin = if (minSample < 0) min(minSample, -wMax * 0.1) else 0.0
         return yMin to yMax
     }
 

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
@@ -42,6 +42,7 @@ private fun statusText(status: WPrimeStatus): String = when (status) {
     WPrimeStatus.DEPLETING -> "DEPLETING"
     WPrimeStatus.CRITICAL -> "CRITICAL"
     WPrimeStatus.EMPTY -> "EMPTY"
+    WPrimeStatus.DEFICIT -> "DEFICIT"
 }
 
 private fun timeLabel(state: ClimbDisplayState): String {

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
@@ -64,6 +64,17 @@ private fun timeLabel(state: ClimbDisplayState): String {
     }
 }
 
+// Red while heading toward empty (a warning state — you're spending W'),
+// green while heading toward full (recovering). Matches the ▼/▲ symbol.
+private fun timeColor(state: ClimbDisplayState): androidx.compose.ui.graphics.Color {
+    val w = state.wPrime
+    return when {
+        w.timeToEmpty > 0 -> GlanceColors.Problem
+        w.timeToFull > 0 -> GlanceColors.Optimal
+        else -> GlanceColors.Label
+    }
+}
+
 @Composable
 private fun WPrimeSmall(state: ClimbDisplayState) {
     val hasData = state.live.hasData
@@ -110,7 +121,7 @@ private fun WPrimeMediumWide(state: ClimbDisplayState) {
                 WPrimeBar(pct, color)
             }
             if (time.isNotEmpty()) {
-                LabelText(time)
+                LabelText(time, color = timeColor(state))
             }
         }
     }
@@ -157,7 +168,7 @@ private fun WPrimeLarge(state: ClimbDisplayState) {
             MetricValueRow("STATUS", status, color, valueFontSize = 18, labelFontSize = 12)
             MetricValueRow("ENERGY", balanceKj, GlanceColors.White, valueFontSize = 18, labelFontSize = 12)
             if (time.isNotEmpty()) {
-                LabelText(time, fontSize = 12)
+                LabelText(time, fontSize = 12, color = timeColor(state))
             }
         }
     }

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
@@ -55,29 +55,25 @@ private fun statusText(status: WPrimeStatus): String = when (status) {
 private const val SYMBOL_EMPTYING = "▼"
 private const val SYMBOL_FILLING = "▲"
 
-// Horizon value sentinels (see WPrimeEngine.HORIZON_SETTLING): 0 means the
-// direction is known but the value is still settling — show "--" so the
-// symbol/colour are correct from the switch but no misleading number appears
-// until the 5 s settle completes.
+// During a direction-change settle the engine holds the PREVIOUS direction's
+// value, so there's no placeholder to render — a positive value is always a
+// real horizon. Hidden (both -1) at full W' and when there's no clear horizon.
 private fun timeLabel(state: ClimbDisplayState): String {
     val w = state.wPrime
     return when {
         w.timeToEmpty > 0 -> "$SYMBOL_EMPTYING ${PhysicsUtils.formatTime(w.timeToEmpty)}"
-        w.timeToEmpty == 0L -> "$SYMBOL_EMPTYING --"
         w.timeToFull > 0 -> "$SYMBOL_FILLING ${PhysicsUtils.formatTime(w.timeToFull)}"
-        w.timeToFull == 0L -> "$SYMBOL_FILLING --"
         else -> ""
     }
 }
 
 // Red while heading toward empty (a warning state — you're spending W'),
 // green while heading toward full (recovering). Matches the ▼/▲ symbol.
-// Applies during the settle window too (>= 0 covers the 0 sentinel).
 private fun timeColor(state: ClimbDisplayState): androidx.compose.ui.graphics.Color {
     val w = state.wPrime
     return when {
-        w.timeToEmpty >= 0 -> GlanceColors.Problem
-        w.timeToFull >= 0 -> GlanceColors.Optimal
+        w.timeToEmpty > 0 -> GlanceColors.Problem
+        w.timeToFull > 0 -> GlanceColors.Optimal
         else -> GlanceColors.Label
     }
 }

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
@@ -45,13 +45,21 @@ private fun statusText(status: WPrimeStatus): String = when (status) {
     WPrimeStatus.DEFICIT -> "DEFICIT"
 }
 
+// Time-horizon symbols. ▼ = heading toward EMPTY (depleting), ▲ = heading
+// toward FULL (recovering). Distinct at a glance even on a tiny field, unlike
+// the old "TTE"/"TTF" whose only difference was an E vs F. Selection keys off
+// timeToEmpty / timeToFull directly — those are already computed from the
+// engine's 30s-smoothed power, so the symbol no longer flips at 1 Hz as
+// instantaneous power crosses CP (the prior bug, which keyed off the raw
+// depletionRate / recoveryRate and also blanked the field on edge ticks).
+private const val SYMBOL_EMPTYING = "▼"
+private const val SYMBOL_FILLING = "▲"
+
 private fun timeLabel(state: ClimbDisplayState): String {
     val w = state.wPrime
     return when {
-        w.depletionRate > 0 && w.timeToEmpty > 0 ->
-            "TTE ${PhysicsUtils.formatTime(w.timeToEmpty)}"
-        w.recoveryRate > 0 && w.timeToFull > 0 ->
-            "TTF ${PhysicsUtils.formatTime(w.timeToFull)}"
+        w.timeToEmpty > 0 -> "$SYMBOL_EMPTYING ${PhysicsUtils.formatTime(w.timeToEmpty)}"
+        w.timeToFull > 0 -> "$SYMBOL_FILLING ${PhysicsUtils.formatTime(w.timeToFull)}"
         else -> ""
     }
 }

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeGlance.kt
@@ -55,22 +55,29 @@ private fun statusText(status: WPrimeStatus): String = when (status) {
 private const val SYMBOL_EMPTYING = "▼"
 private const val SYMBOL_FILLING = "▲"
 
+// Horizon value sentinels (see WPrimeEngine.HORIZON_SETTLING): 0 means the
+// direction is known but the value is still settling — show "--" so the
+// symbol/colour are correct from the switch but no misleading number appears
+// until the 5 s settle completes.
 private fun timeLabel(state: ClimbDisplayState): String {
     val w = state.wPrime
     return when {
         w.timeToEmpty > 0 -> "$SYMBOL_EMPTYING ${PhysicsUtils.formatTime(w.timeToEmpty)}"
+        w.timeToEmpty == 0L -> "$SYMBOL_EMPTYING --"
         w.timeToFull > 0 -> "$SYMBOL_FILLING ${PhysicsUtils.formatTime(w.timeToFull)}"
+        w.timeToFull == 0L -> "$SYMBOL_FILLING --"
         else -> ""
     }
 }
 
 // Red while heading toward empty (a warning state — you're spending W'),
 // green while heading toward full (recovering). Matches the ▼/▲ symbol.
+// Applies during the settle window too (>= 0 covers the 0 sentinel).
 private fun timeColor(state: ClimbDisplayState): androidx.compose.ui.graphics.Color {
     val w = state.wPrime
     return when {
-        w.timeToEmpty > 0 -> GlanceColors.Problem
-        w.timeToFull > 0 -> GlanceColors.Optimal
+        w.timeToEmpty >= 0 -> GlanceColors.Problem
+        w.timeToFull >= 0 -> GlanceColors.Optimal
         else -> GlanceColors.Label
     }
 }

--- a/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeHistoryGlance.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/datatypes/glance/WPrimeHistoryGlance.kt
@@ -1,0 +1,72 @@
+package io.github.climbintelligence.datatypes.glance
+
+import androidx.compose.runtime.Composable
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.fillMaxSize
+import io.github.climbintelligence.ClimbIntelligenceExtension
+import io.github.climbintelligence.data.model.WPrimeSample
+import io.github.climbintelligence.datatypes.BaseDataType
+import io.github.climbintelligence.datatypes.ClimbDisplayState
+import io.github.climbintelligence.datatypes.GlanceDataType
+import io.hammerhead.karooext.models.ViewConfig
+
+/**
+ * Karoo data field rendering the W' balance history as a chart. The line goes
+ * green above the zero baseline and purple below (Luigi's DEFICIT color) so
+ * the rider sees reserve-depth excursions at a glance. Underlying drawing is
+ * done in [WPrimeChartRenderer] (off-screen Bitmap + Canvas — the only way
+ * Glance widgets can render smooth curves).
+ *
+ * v1 keeps it simple: every 1Hz tick re-renders the full-ride history.
+ * Throttle + rolling-window trim are deferred until ride feedback motivates
+ * them — both prefs already exist in [PreferencesRepository], they just
+ * aren't read yet.
+ */
+class WPrimeHistoryGlanceDataType(extension: ClimbIntelligenceExtension) :
+    GlanceDataType(extension, "wprime-history") {
+
+    @Composable
+    override fun Content(state: ClimbDisplayState, config: ViewConfig) {
+        val layoutSize = BaseDataType.getLayoutSize(config)
+        DataFieldContainer {
+            when (layoutSize) {
+                BaseDataType.LayoutSize.SMALL -> Render(state, 100, 60, ChartMode.Sparkline)
+                BaseDataType.LayoutSize.SMALL_WIDE -> Render(state, 200, 60, ChartMode.MiniWithCurrent)
+                BaseDataType.LayoutSize.MEDIUM -> Render(state, 160, 100, ChartMode.MiniWithCurrent)
+                BaseDataType.LayoutSize.MEDIUM_WIDE -> Render(state, 240, 80, ChartMode.MiniWithCurrent)
+                BaseDataType.LayoutSize.LARGE -> Render(state, 280, 160, ChartMode.FullDualAxis)
+                BaseDataType.LayoutSize.NARROW -> Render(state, 60, 140, ChartMode.Vertical)
+            }
+        }
+    }
+}
+
+@Composable
+private fun Render(state: ClimbDisplayState, width: Int, height: Int, mode: ChartMode) {
+    val samples: List<WPrimeSample> = state.wPrimeHistory
+    val wMax = state.wPrime.maxBalance
+
+    if (samples.isEmpty() || wMax <= 0.0 || !state.live.hasData) {
+        // Show "—" placeholder when there's no data yet
+        Box(
+            modifier = GlanceModifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            ValueText("—", GlanceColors.Label, 24)
+        }
+        return
+    }
+
+    val bitmap = WPrimeChartRenderer.renderChart(samples, width, height, mode, wMax)
+    Box(modifier = GlanceModifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Image(
+            provider = ImageProvider(bitmap),
+            contentDescription = null,
+            modifier = GlanceModifier.fillMaxSize()
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/AlertManager.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/AlertManager.kt
@@ -21,6 +21,7 @@ class AlertManager(
     companion object {
         private const val TAG = "AlertManager"
         private const val ALERT_WPRIME = "climb_wprime"
+        private const val ALERT_WPRIME_DEFICIT = "climb_wprime_deficit"
         private const val ALERT_STEEP = "climb_steep"
         private const val ALERT_SUMMIT = "climb_summit"
         private const val ALERT_CLIMB_START = "climb_started"
@@ -30,6 +31,7 @@ class AlertManager(
     private var scope: CoroutineScope? = null
 
     private val wPrimeLastAlert = AtomicLong(0)
+    private val wPrimeDeficitLastAlert = AtomicLong(0)
     private val steepLastAlert = AtomicLong(0)
     private val summitLastAlert = AtomicLong(0)
     private val climbStartLastAlert = AtomicLong(0)
@@ -39,12 +41,16 @@ class AlertManager(
     @Volatile private var cooldownMs = 30_000L
     @Volatile private var wPrimeAlertThreshold = 20.0
     @Volatile private var alertWPrimeEnabled = true
+    @Volatile private var alertWPrimeDeficitEnabled = true
     @Volatile private var alertSteepEnabled = true
     @Volatile private var alertSummitEnabled = true
     @Volatile private var alertClimbStartEnabled = true
 
     /** Track whether W' was previously below threshold — alert only fires on crossing */
     @Volatile private var wasWPrimeBelowThreshold = false
+
+    /** Track whether W' was previously below 0% — DEFICIT alert fires once per crossing */
+    @Volatile private var wasWPrimeBelowZero = false
 
     fun startMonitoring() {
         scope?.cancel()
@@ -64,6 +70,9 @@ class AlertManager(
         }
         scope?.launch {
             preferencesRepository.alertWPrimeFlow.collect { alertWPrimeEnabled = it }
+        }
+        scope?.launch {
+            preferencesRepository.alertWPrimeDeficitFlow.collect { alertWPrimeDeficitEnabled = it }
         }
         scope?.launch {
             preferencesRepository.alertSteepFlow.collect { alertSteepEnabled = it }
@@ -113,6 +122,25 @@ class AlertManager(
                     )
                 }
                 wasWPrimeBelowThreshold = isBelow
+
+                // DEFICIT alert: one-shot on crossing below 0%. Fires independently
+                // of the W' critical alert (a rider can have both fire in sequence on
+                // the same drawdown). Carries a different message: the deficit is the
+                // model's signal that W'max may be calibrated too low for this rider.
+                val isInDeficit = wPrimeState.percentage < 0
+                if (isInDeficit && !wasWPrimeBelowZero && alertWPrimeDeficitEnabled) {
+                    val pctInt = wPrimeState.percentage.toInt()
+                    val title = extension.getString(R.string.alert_wprime_deficit_title, pctInt)
+                    val detail = extension.getString(R.string.alert_wprime_deficit_detail)
+                    dispatchWithCooldown(
+                        lastAlert = wPrimeDeficitLastAlert,
+                        alertId = ALERT_WPRIME_DEFICIT,
+                        title = title,
+                        detail = detail,
+                        urgent = true
+                    )
+                }
+                wasWPrimeBelowZero = isInDeficit
             }
         }
 
@@ -296,10 +324,12 @@ class AlertManager(
 
     fun reset() {
         wPrimeLastAlert.set(0)
+        wPrimeDeficitLastAlert.set(0)
         steepLastAlert.set(0)
         summitLastAlert.set(0)
         climbStartLastAlert.set(0)
         wasWPrimeBelowThreshold = false
+        wasWPrimeBelowZero = false
     }
 
     fun destroy() {

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/ClimbStatsTracker.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/ClimbStatsTracker.kt
@@ -52,8 +52,8 @@ class ClimbStatsTracker(preferencesRepository: PreferencesRepository) {
     init {
         scope.launch {
             preferencesRepository.athleteProfileFlow.collect { profile ->
-                if (profile.isConfigured && profile.weight > 0) {
-                    weight = profile.weight
+                if (profile.isConfigured && profile.effectiveWeight > 0) {
+                    weight = profile.effectiveWeight
                     profileLoaded = true
                 }
             }

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/MetricsEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/MetricsEngine.kt
@@ -43,7 +43,7 @@ class MetricsEngine(preferencesRepository: PreferencesRepository) {
     init {
         scope.launch {
             preferencesRepository.athleteProfileFlow.collect { p ->
-                ftp = p.ftp
+                ftp = p.effectiveFtp
             }
         }
         scope.launch {

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/PacingCalculator.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/PacingCalculator.kt
@@ -155,7 +155,7 @@ class PacingCalculator(private val preferencesRepository: PreferencesRepository)
     private fun calculateTargetPower(grade: Double, altitude: Double): Int {
         if (grade < 1.0) return 0 // Only pace on climbs
 
-        val ftp = (if (effectiveFtpOverride > 0) effectiveFtpOverride else profile.ftp).toDouble()
+        val ftp = (if (effectiveFtpOverride > 0) effectiveFtpOverride else profile.effectiveFtp).toDouble()
         if (ftp <= 0) return 0
 
         // Reuse cached result if inputs unchanged

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/RideStateMonitor.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/RideStateMonitor.kt
@@ -4,8 +4,11 @@ import io.github.climbintelligence.ClimbIntelligenceExtension
 import io.hammerhead.karooext.models.RideState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicReference
 
@@ -25,6 +28,14 @@ class RideStateMonitor(
 
     @Volatile
     private var rideStartTimeMs = 0L
+
+    /**
+     * Active while the Karoo ride is in [RideState.Paused]. Ticks
+     * [WPrimeEngine.tickPauseRecovery] at 1 Hz so pause time accumulates
+     * toward W' refill as if the rider were coasting.
+     */
+    @Volatile
+    private var pauseTickerJob: Job? = null
 
     fun startMonitoring() {
         if (!extension.karooSystem.connected) return
@@ -55,6 +66,12 @@ class RideStateMonitor(
 
         when (rideState) {
             is RideState.Recording -> {
+                // Cover the resume-from-pause edge: Recording fires whether
+                // this is a fresh ride start or a resume — in either case
+                // the pause ticker must be off.
+                stopPauseTicker()
+                extension.wPrimeEngine.setPaused(false)
+
                 if (!wasRecording) {
                     wasRecording = true
                     rideStartTimeMs = System.currentTimeMillis()
@@ -83,9 +100,18 @@ class RideStateMonitor(
                         extension.climbDataService
                     )
                 }
+                // Mark engine paused + drive recovery at 1 Hz. The Skiba
+                // model says recovery applies whenever P ≤ CP, and during
+                // pause the rider's effective power is 0, so pause time
+                // must accumulate toward W' refill the same as coasting.
+                extension.wPrimeEngine.setPaused(true)
+                startPauseTicker()
             }
 
             is RideState.Idle -> {
+                stopPauseTicker()
+                extension.wPrimeEngine.setPaused(false)
+
                 if (wasRecording) {
                     wasRecording = false
 
@@ -126,7 +152,27 @@ class RideStateMonitor(
 
     fun isRecording(): Boolean = wasRecording
 
+    private fun startPauseTicker() {
+        if (pauseTickerJob?.isActive == true) return
+        pauseTickerJob = scope.launch {
+            while (isActive) {
+                extension.wPrimeEngine.tickPauseRecovery(System.currentTimeMillis())
+                delay(1000)
+            }
+        }
+        android.util.Log.i(TAG, "Pause recovery ticker started")
+    }
+
+    private fun stopPauseTicker() {
+        pauseTickerJob?.let {
+            it.cancel()
+            android.util.Log.i(TAG, "Pause recovery ticker stopped")
+        }
+        pauseTickerJob = null
+    }
+
     fun destroy() {
+        stopPauseTicker()
         stopMonitoring()
         scope.cancel()
     }

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -190,13 +190,15 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         val smoothedDepletion = if (smoothedPower > cp) (smoothedPower - cp) else 0.0
         val smoothedRecovery = if (smoothedPower <= cp) recovery else 0.0
 
-        // timeToEmpty only meaningful when balance is positive and depleting
+        // timeToEmpty only meaningful when balance is positive and depleting.
+        // Round to the nearest 5 s so the displayed countdown doesn't jitter
+        // by ±1-2 s from rate-window noise — pacing reads on a coarser scale.
         val timeToEmpty = if (wBalance > 0 && smoothedDepletion > smoothedRecovery && smoothedDepletion > 0) {
-            (wBalance / (smoothedDepletion - smoothedRecovery)).toLong().coerceAtMost(3600L)
+            roundTo5((wBalance / (smoothedDepletion - smoothedRecovery)).toLong().coerceAtMost(3600L))
         } else -1L
 
         val timeToFull = if (smoothedRecovery > 0 && wBalance < wMax) {
-            ((wMax - wBalance) / smoothedRecovery).toLong().coerceAtMost(3600L)
+            roundTo5(((wMax - wBalance) / smoothedRecovery).toLong().coerceAtMost(3600L))
         } else -1L
 
         _state.value = WPrimeState(
@@ -279,6 +281,12 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
      * Falls back to TAU_BASE + TAU_FLOOR when no below-CP samples exist yet
      * (start of a ride before any coasting).
      */
+    /** Round a positive second count to the nearest 5 s, keeping a 5 s floor
+     *  so a still-positive horizon never rounds down to 0 (which would make
+     *  the field's label vanish for the final ticks). */
+    private fun roundTo5(seconds: Long): Long =
+        if (seconds <= 0) seconds else maxOf(5L, ((seconds + 2L) / 5L) * 5L)
+
     private fun currentTau(): Double {
         if (countPowerBelowCp == 0L) return TAU_BASE + TAU_FLOOR
         val avgBelow = sumPowerBelowCp / countPowerBelowCp

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -3,6 +3,7 @@ package io.github.climbintelligence.engine
 import io.github.climbintelligence.data.PreferencesRepository
 import io.github.climbintelligence.data.model.AthleteProfile
 import io.github.climbintelligence.data.model.LiveClimbState
+import io.github.climbintelligence.data.model.WPrimeSample
 import io.github.climbintelligence.data.model.WPrimeState
 import io.github.climbintelligence.data.model.WPrimeStatus
 import kotlinx.coroutines.CoroutineScope
@@ -20,6 +21,12 @@ import kotlinx.coroutines.launch
  * if P > CP: dW' = ((W'max - W') / tau - (P - CP)) * dt
  * if P <= CP: dW' = ((W'max - W') / tau) * dt
  * tau = 546.0 (Skiba constant)
+ *
+ * As of the W'-history-chart PR, balance is allowed to be negative — the
+ * Skiba math predicts depletion past zero whenever power > CP for long
+ * enough, and that signal is the model's way of saying "W'max is calibrated
+ * too low for this rider." A sanity floor at -wMax keeps a stuck-high sensor
+ * from driving the value to absurd negatives.
  */
 class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
 
@@ -27,10 +34,23 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         private const val TAG = "WPrimeEngine"
         private const val TAU = 546.0 // Skiba recovery time constant
         private const val DT = 1.0    // 1 second update interval
+        /** Ring-buffer cap for per-tick history. 86400 = 24h at 1Hz, ~2.8 MB. */
+        const val MAX_HISTORY_SAMPLES = 86400
     }
 
     private val _state = MutableStateFlow(WPrimeState())
     val state: StateFlow<WPrimeState> = _state.asStateFlow()
+
+    /**
+     * Per-tick W' history for the current ride. Append-on-update, ring-buffered
+     * at MAX_HISTORY_SAMPLES. Cleared on reset(); NOT restored across crashes
+     * (CheckpointManager restores current balance but not history — chart
+     * resumes from the current value after a restart).
+     */
+    private val _wPrimeHistory = MutableStateFlow<List<WPrimeSample>>(emptyList())
+    val wPrimeHistory: StateFlow<List<WPrimeSample>> = _wPrimeHistory.asStateFlow()
+
+    private val historyBuffer = ArrayDeque<WPrimeSample>()
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -85,13 +105,17 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             recovery * dt
         }
 
-        wBalance = (wBalance + dW).coerceIn(0.0, wMax)
+        // Allow negative — that's the model's signal that W'max is calibrated too low.
+        // Cap above at wMax (can't exceed the model's max capacity) and floor at -wMax
+        // (sanity bound — a stuck-high sensor can't drift to absurd negatives).
+        wBalance = (wBalance + dW).coerceIn(-wMax, wMax)
 
         val pct = wBalance / wMax * 100.0
         val depletionRate = if (power > cp) (power - cp) else 0.0
         val recoveryRateVal = if (power <= cp) recovery else 0.0
 
-        val timeToEmpty = if (depletionRate > recoveryRateVal && depletionRate > 0) {
+        // timeToEmpty only meaningful when balance is positive and depleting
+        val timeToEmpty = if (wBalance > 0 && depletionRate > recoveryRateVal && depletionRate > 0) {
             (wBalance / (depletionRate - recoveryRateVal)).toLong().coerceAtMost(3600L)
         } else -1L
 
@@ -107,25 +131,51 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             recoveryRate = recoveryRateVal,
             timeToEmpty = timeToEmpty,
             timeToFull = timeToFull,
-            status = when {
-                pct > 90 -> WPrimeStatus.FRESH
-                pct > 70 -> WPrimeStatus.GOOD
-                pct > 50 -> WPrimeStatus.WORKING
-                pct > 30 -> WPrimeStatus.DEPLETING
-                pct > 10 -> WPrimeStatus.CRITICAL
-                else -> WPrimeStatus.EMPTY
-            }
+            status = WPrimeState.statusForPercentage(pct)
         )
+
+        // Append to history ring buffer + publish updated list
+        recordHistorySample(now, wBalance, pct, state.power)
+    }
+
+    private fun recordHistorySample(
+        timestampMs: Long,
+        balance: Double,
+        percentage: Double,
+        power: Int
+    ) {
+        historyBuffer.addLast(
+            WPrimeSample(
+                timestampMs = timestampMs,
+                balance = balance,
+                percentage = percentage,
+                power = power
+            )
+        )
+        while (historyBuffer.size > MAX_HISTORY_SAMPLES) {
+            historyBuffer.removeFirst()
+        }
+        // Publish an immutable snapshot to the StateFlow. ArrayList copy keeps
+        // collectors safe from concurrent mutation of historyBuffer.
+        _wPrimeHistory.value = ArrayList(historyBuffer)
     }
 
     fun reset() {
         wBalance = wMax
         lastUpdateTime = 0L
+        historyBuffer.clear()
+        _wPrimeHistory.value = emptyList()
         _state.value = WPrimeState(balance = wMax, maxBalance = wMax)
     }
 
+    /**
+     * Restore current balance from a checkpoint. History is NOT restored —
+     * the chart resumes from this point with no prior history shown. A future
+     * `chore/restore-history-from-fit` PR could read the in-progress FIT
+     * file to reconstruct samples up to the crash; out of scope here.
+     */
     fun restore(balance: Double) {
-        wBalance = balance.coerceIn(0.0, wMax)
+        wBalance = balance.coerceIn(-wMax, wMax)
         _state.value = WPrimeState.fromBalance(wBalance, wMax)
     }
 }

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlin.math.exp
+import kotlin.math.pow
 
 /**
  * Skiba differential W' Balance model.
@@ -32,7 +34,12 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
 
     companion object {
         private const val TAG = "WPrimeEngine"
-        private const val TAU = 546.0 // Skiba recovery time constant
+        /** Skiba recovery time-constant baseline. With the dynamic-τ formula
+         *  enabled, this is the long-coast asymptote ceiling (when the rider
+         *  is exactly at CP the formula reduces to TAU_BASE + TAU_FLOOR). */
+        private const val TAU_BASE = 546.0
+        /** Floor added to keep τ from collapsing to zero on deep-rest coasting. */
+        private const val TAU_FLOOR = 316.0
         private const val DT = 1.0    // 1 second update interval
         /** Ring-buffer cap for per-tick history. 86400 = 24h at 1Hz, ~2.8 MB. */
         const val MAX_HISTORY_SAMPLES = 86400
@@ -57,8 +64,14 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
     private var wBalance: Double = 20000.0
     private var wMax: Double = 20000.0
     private var cp: Int = 0
+    private var pMax: Int = 0
+    private var useThreeParamModel: Boolean = false
     private var lastUpdateTime: Long = 0L
     private var profileLoaded = false
+
+    // Rolling stats for the dynamic-τ formula. Reset on reset().
+    private var sumPowerBelowCp: Double = 0.0
+    private var countPowerBelowCp: Long = 0L
 
     /**
      * True while the Karoo ride is in [io.hammerhead.karooext.models.RideState.Paused].
@@ -76,6 +89,8 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
                 if (profile.isConfigured) {
                     val newMax = profile.wPrimeMax.toDouble()
                     cp = profile.effectiveCp
+                    pMax = profile.maxPower
+                    useThreeParamModel = profile.useThreeParamModel
                     if (!profileLoaded) {
                         wMax = newMax
                         wBalance = newMax
@@ -109,7 +124,16 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
 
         val now = state.timestamp
         val power = state.power.toDouble()
-        val recovery = (wMax - wBalance) / TAU
+
+        // Accumulate average power below CP for the dynamic-τ formula. Done
+        // BEFORE computing recovery so the current sample is reflected in τ
+        // when the rider is coasting.
+        if (power <= cp) {
+            sumPowerBelowCp += power
+            countPowerBelowCp++
+        }
+
+        val recovery = (wMax - wBalance) / currentTau()
 
         // Compute balance delta only when we have a previous timestamp to diff
         // against. On the very first tick we just seed lastUpdateTime + record
@@ -155,7 +179,8 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             recoveryRate = recoveryRateVal,
             timeToEmpty = timeToEmpty,
             timeToFull = timeToFull,
-            status = WPrimeState.statusForPercentage(pct)
+            status = WPrimeState.statusForPercentage(pct),
+            mpa = computeMpa(),
         )
 
         // Append to history every tick where sensor data is flowing — including
@@ -180,7 +205,12 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         if (!profileLoaded || cp == 0) return
         if (!pauseActive) return // belt-and-suspenders; only run while paused
 
-        val recovery = (wMax - wBalance) / TAU
+        // Pause is power=0 ≤ CP — feed the dynamic-τ rolling average so τ
+        // continues to adapt while the rider rests.
+        sumPowerBelowCp += 0.0
+        countPowerBelowCp++
+
+        val recovery = (wMax - wBalance) / currentTau()
 
         if (lastUpdateTime != 0L) {
             val rawDt = (now - lastUpdateTime) / 1000.0
@@ -190,7 +220,7 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         lastUpdateTime = now
 
         val pct = wBalance / wMax * 100.0
-        val recoveryRateVal = (wMax - wBalance) / TAU
+        val recoveryRateVal = (wMax - wBalance) / currentTau()
         val timeToFull = if (recoveryRateVal > 0 && wBalance < wMax) {
             ((wMax - wBalance) / recoveryRateVal).toLong().coerceAtMost(3600L)
         } else -1L
@@ -203,10 +233,42 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             recoveryRate = recoveryRateVal,
             timeToEmpty = -1L,
             timeToFull = timeToFull,
-            status = WPrimeState.statusForPercentage(pct)
+            status = WPrimeState.statusForPercentage(pct),
+            mpa = computeMpa(),
         )
 
         recordHistorySample(now, wBalance, pct, power = 0)
+    }
+
+    /**
+     * Dynamic τ adapts the recovery time-constant to how far the rider's
+     * coasting power is below CP. A bigger deficit (rider truly resting at
+     * 50W) means faster recovery (lower τ); a small deficit (just below CP)
+     * means slower recovery (longer τ).
+     *
+     * τ = TAU_BASE · exp(-0.01 · (CP − avgPowerBelowCP)) + TAU_FLOOR
+     *
+     * Falls back to TAU_BASE + TAU_FLOOR when no below-CP samples exist yet
+     * (start of a ride before any coasting).
+     */
+    private fun currentTau(): Double {
+        if (countPowerBelowCp == 0L) return TAU_BASE + TAU_FLOOR
+        val avgBelow = sumPowerBelowCp / countPowerBelowCp
+        val deltaCp = cp - avgBelow
+        return TAU_BASE * exp(-0.01 * deltaCp) + TAU_FLOOR
+    }
+
+    /**
+     * Morton 3-parameter Maximum Power Available. Returns 0 unless the rider
+     * has configured Pmax AND enabled the three-parameter toggle — the model
+     * needs a calibrated Pmax to mean anything. Negative W' (DEFICIT) clamps
+     * the fatigue ratio at 1.0 so MPA bottoms out at CP, not below.
+     */
+    private fun computeMpa(): Int {
+        if (!useThreeParamModel || pMax <= cp || wMax <= 0.0) return 0
+        val fatigueRatio = ((wMax - wBalance) / wMax).coerceIn(0.0, 1.0)
+        val mpaWatts = pMax - (pMax - cp) * fatigueRatio.pow(2.0)
+        return mpaWatts.toInt().coerceAtLeast(cp)
     }
 
     private fun recordHistorySample(
@@ -234,6 +296,8 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
     fun reset() {
         wBalance = wMax
         lastUpdateTime = 0L
+        sumPowerBelowCp = 0.0
+        countPowerBelowCp = 0L
         historyBuffer.clear()
         _wPrimeHistory.value = emptyList()
         _state.value = WPrimeState(balance = wMax, maxBalance = wMax)

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -50,6 +50,11 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
          *  "at the rider's current sustained effort" which is what's
          *  actionable for pacing. */
         private const val TTE_TTF_SMOOTH_WINDOW_MS = 30_000L
+        /** Hold the published TTE/TTF horizon steady for this long, then
+         *  refresh. Even with 30 s-smoothed inputs the second-by-second value
+         *  drifts; the field is consumed at a glance, so a 5 s refresh cadence
+         *  reads as "stable" rather than "counting". */
+        private const val HORIZON_PUBLISH_INTERVAL_MS = 5_000L
     }
 
     private val _state = MutableStateFlow(WPrimeState())
@@ -83,6 +88,13 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
     /** Rolling 30 s power window for TTE/TTF smoothing. Holds (timestampMs,
      *  power) pairs trimmed every update() to entries within the window. */
     private val recentPowerWindow = ArrayDeque<Pair<Long, Int>>()
+
+    // Published (held) TTE/TTF horizons — refreshed at most every
+    // HORIZON_PUBLISH_INTERVAL_MS so the displayed countdown holds steady
+    // between refreshes instead of changing every tick.
+    private var publishedTimeToEmpty: Long = -1L
+    private var publishedTimeToFull: Long = -1L
+    private var lastHorizonPublishMs: Long = 0L
 
     /**
      * True while the Karoo ride is in [io.hammerhead.karooext.models.RideState.Paused].
@@ -193,13 +205,21 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         // timeToEmpty only meaningful when balance is positive and depleting.
         // Round to the nearest 5 s so the displayed countdown doesn't jitter
         // by ±1-2 s from rate-window noise — pacing reads on a coarser scale.
-        val timeToEmpty = if (wBalance > 0 && smoothedDepletion > smoothedRecovery && smoothedDepletion > 0) {
+        val computedTimeToEmpty = if (wBalance > 0 && smoothedDepletion > smoothedRecovery && smoothedDepletion > 0) {
             roundTo5((wBalance / (smoothedDepletion - smoothedRecovery)).toLong().coerceAtMost(3600L))
         } else -1L
 
-        val timeToFull = if (smoothedRecovery > 0 && wBalance < wMax) {
+        val computedTimeToFull = if (smoothedRecovery > 0 && wBalance < wMax) {
             roundTo5(((wMax - wBalance) / smoothedRecovery).toLong().coerceAtMost(3600L))
         } else -1L
+
+        // Hold the published horizon steady for HORIZON_PUBLISH_INTERVAL_MS,
+        // then refresh — so the field updates on a ~5 s cadence, not 1 Hz.
+        if (lastHorizonPublishMs == 0L || now - lastHorizonPublishMs >= HORIZON_PUBLISH_INTERVAL_MS) {
+            publishedTimeToEmpty = computedTimeToEmpty
+            publishedTimeToFull = computedTimeToFull
+            lastHorizonPublishMs = now
+        }
 
         _state.value = WPrimeState(
             balance = wBalance,
@@ -207,8 +227,8 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             percentage = pct,
             depletionRate = depletionRate,
             recoveryRate = recoveryRateVal,
-            timeToEmpty = timeToEmpty,
-            timeToFull = timeToFull,
+            timeToEmpty = publishedTimeToEmpty,
+            timeToFull = publishedTimeToFull,
             status = WPrimeState.statusForPercentage(pct),
             mpa = computeMpa(),
         )
@@ -335,6 +355,9 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         sumPowerBelowCp = 0.0
         countPowerBelowCp = 0L
         recentPowerWindow.clear()
+        publishedTimeToEmpty = -1L
+        publishedTimeToFull = -1L
+        lastHorizonPublishMs = 0L
         historyBuffer.clear()
         _wPrimeHistory.value = emptyList()
         _state.value = WPrimeState(balance = wMax, maxBalance = wMax)

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -64,9 +64,11 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
          *  with a "--" placeholder (no layout jump). Parameter-free — no
          *  athlete-specific tuning. */
         private const val HORIZON_SETTLE_MS = 5_000L
-        /** Sentinel in published TTE/TTF: 0 = "this direction, still settling"
-         *  (render symbol + "--"); -1 = not this direction; >0 = settled value. */
-        const val HORIZON_SETTLING = 0L
+        /** At or above this percentage the rider is treated as fully recovered
+         *  — the TTE/TTF horizon is hidden (nothing to recover to, not yet
+         *  spending). 99.5 because recovery asymptotes toward wMax and the
+         *  field rounds the percentage to a whole number. */
+        private const val FULL_PCT = 99.5
     }
 
     private val _state = MutableStateFlow(WPrimeState())
@@ -230,10 +232,10 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             roundTo5(((wMax - wBalance) / smoothedRecovery).toLong().coerceAtMost(3600L))
         } else -1L
 
-        // Determine the current horizon direction and track when it last
-        // changed. A direction change resets the settle clock + the publish
-        // hold so the new direction re-settles before showing a number.
+        // Determine the current horizon direction. At full W' the horizon is
+        // hidden outright (nothing to recover to, not yet spending).
         val currentDir = when {
+            pct >= FULL_PCT -> HorizonDir.NONE
             computedTimeToEmpty > 0 -> HorizonDir.EMPTYING
             computedTimeToFull > 0 -> HorizonDir.FILLING
             else -> HorizonDir.NONE
@@ -243,29 +245,24 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             horizonDirSinceMs = now
             lastHorizonPublishMs = 0L
         }
-        val settled = currentDir != HorizonDir.NONE &&
-            now - horizonDirSinceMs >= HORIZON_SETTLE_MS
 
-        when {
-            currentDir == HorizonDir.NONE -> {
-                publishedTimeToEmpty = -1L
-                publishedTimeToFull = -1L
-            }
-            !settled -> {
-                // Settling: expose the direction (so the symbol + "--"
-                // placeholder shows, no layout jump) but withhold the number.
-                publishedTimeToEmpty = if (currentDir == HorizonDir.EMPTYING) HORIZON_SETTLING else -1L
-                publishedTimeToFull = if (currentDir == HorizonDir.FILLING) HORIZON_SETTLING else -1L
-            }
-            else -> {
-                // Settled: refresh the real value on the 5 s hold cadence.
-                if (lastHorizonPublishMs == 0L || now - lastHorizonPublishMs >= HORIZON_PUBLISH_INTERVAL_MS) {
-                    publishedTimeToEmpty = if (currentDir == HorizonDir.EMPTYING) computedTimeToEmpty else -1L
-                    publishedTimeToFull = if (currentDir == HorizonDir.FILLING) computedTimeToFull else -1L
-                    lastHorizonPublishMs = now
-                }
+        if (currentDir == HorizonDir.NONE) {
+            // Full, or no clear horizon — hide the line.
+            publishedTimeToEmpty = -1L
+            publishedTimeToFull = -1L
+        } else if (now - horizonDirSinceMs >= HORIZON_SETTLE_MS) {
+            // Settled (≥5 s in this direction): refresh the real value on the
+            // hold cadence.
+            if (lastHorizonPublishMs == 0L || now - lastHorizonPublishMs >= HORIZON_PUBLISH_INTERVAL_MS) {
+                publishedTimeToEmpty = if (currentDir == HorizonDir.EMPTYING) computedTimeToEmpty else -1L
+                publishedTimeToFull = if (currentDir == HorizonDir.FILLING) computedTimeToFull else -1L
+                lastHorizonPublishMs = now
             }
         }
+        // else (direction changed, still settling): leave the published values
+        // untouched — keep showing the PREVIOUS direction's last value (e.g. a
+        // green ▲ recovery time) through the 5 s settle, then swap to the new
+        // direction once its value is real. No "--" placeholder, no jump.
 
         _state.value = WPrimeState(
             balance = wBalance,

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -43,6 +43,13 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         private const val DT = 1.0    // 1 second update interval
         /** Ring-buffer cap for per-tick history. 86400 = 24h at 1Hz, ~2.8 MB. */
         const val MAX_HISTORY_SAMPLES = 86400
+        /** Rolling-window length for the smoothed power that drives the
+         *  TTE/TTF projections. Power fluctuates around CP every second on
+         *  real rides, so a per-tick projection flips between depletion and
+         *  recovery branches as noise; a 30 s mean reframes the question as
+         *  "at the rider's current sustained effort" which is what's
+         *  actionable for pacing. */
+        private const val TTE_TTF_SMOOTH_WINDOW_MS = 30_000L
     }
 
     private val _state = MutableStateFlow(WPrimeState())
@@ -72,6 +79,10 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
     // Rolling stats for the dynamic-τ formula. Reset on reset().
     private var sumPowerBelowCp: Double = 0.0
     private var countPowerBelowCp: Long = 0L
+
+    /** Rolling 30 s power window for TTE/TTF smoothing. Holds (timestampMs,
+     *  power) pairs trimmed every update() to entries within the window. */
+    private val recentPowerWindow = ArrayDeque<Pair<Long, Int>>()
 
     /**
      * True while the Karoo ride is in [io.hammerhead.karooext.models.RideState.Paused].
@@ -162,13 +173,30 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         val depletionRate = if (power > cp) (power - cp) else 0.0
         val recoveryRateVal = if (power <= cp) recovery else 0.0
 
+        // Maintain the rolling power window (TTE/TTF smoothing). Trim entries
+        // older than the window from the front; append the current sample.
+        recentPowerWindow.addLast(now to state.power)
+        while (recentPowerWindow.isNotEmpty() &&
+               now - recentPowerWindow.first().first > TTE_TTF_SMOOTH_WINDOW_MS) {
+            recentPowerWindow.removeFirst()
+        }
+        val smoothedPower =
+            if (recentPowerWindow.isEmpty()) power
+            else recentPowerWindow.map { it.second.toDouble() }.average()
+
+        // Smoothed depletion / recovery used ONLY for the TTE/TTF horizons —
+        // the displayed `depletionRate` / `recoveryRate` and the chart still
+        // track instantaneous values so the rider sees real-time response.
+        val smoothedDepletion = if (smoothedPower > cp) (smoothedPower - cp) else 0.0
+        val smoothedRecovery = if (smoothedPower <= cp) recovery else 0.0
+
         // timeToEmpty only meaningful when balance is positive and depleting
-        val timeToEmpty = if (wBalance > 0 && depletionRate > recoveryRateVal && depletionRate > 0) {
-            (wBalance / (depletionRate - recoveryRateVal)).toLong().coerceAtMost(3600L)
+        val timeToEmpty = if (wBalance > 0 && smoothedDepletion > smoothedRecovery && smoothedDepletion > 0) {
+            (wBalance / (smoothedDepletion - smoothedRecovery)).toLong().coerceAtMost(3600L)
         } else -1L
 
-        val timeToFull = if (recoveryRateVal > 0 && wBalance < wMax) {
-            ((wMax - wBalance) / recoveryRateVal).toLong().coerceAtMost(3600L)
+        val timeToFull = if (smoothedRecovery > 0 && wBalance < wMax) {
+            ((wMax - wBalance) / smoothedRecovery).toLong().coerceAtMost(3600L)
         } else -1L
 
         _state.value = WPrimeState(
@@ -298,6 +326,7 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         lastUpdateTime = 0L
         sumPowerBelowCp = 0.0
         countPowerBelowCp = 0L
+        recentPowerWindow.clear()
         historyBuffer.clear()
         _wPrimeHistory.value = emptyList()
         _state.value = WPrimeState(balance = wMax, maxBalance = wMax)

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -82,33 +82,40 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
 
     fun update(state: LiveClimbState) {
         if (!profileLoaded || cp == 0) return
-        if (!state.hasData || state.power == 0) return
+        // Gate ONLY on the presence of sensor data, not on power being non-zero.
+        // power == 0 is a legitimate observation (rider coasting, recovery phase) —
+        // the Skiba math handles it correctly (recovery branch applies). The prior
+        // code's early-return on power == 0 froze the model AND the history during
+        // coasting, hiding the recovery curve and leaving the chart empty for
+        // riders who hadn't yet pedaled at full power.
+        if (!state.hasData) return
 
         val now = state.timestamp
-        if (lastUpdateTime == 0L) {
-            lastUpdateTime = now
-            return
-        }
-
-        val rawDt = (now - lastUpdateTime) / 1000.0
-        lastUpdateTime = now
-        // Clamp dt: minimum 0.1s prevents freeze on same-timestamp events,
-        // maximum 5s caps large gaps (e.g. after pause)
-        val dt = rawDt.coerceIn(0.1, 5.0)
-
         val power = state.power.toDouble()
         val recovery = (wMax - wBalance) / TAU
 
-        val dW = if (power > cp) {
-            (recovery - (power - cp)) * dt
-        } else {
-            recovery * dt
-        }
+        // Compute balance delta only when we have a previous timestamp to diff
+        // against. On the very first tick we just seed lastUpdateTime + record
+        // the baseline sample — no dW, no compute, but the chart gets its
+        // first data point immediately rather than starting one tick late.
+        if (lastUpdateTime != 0L) {
+            val rawDt = (now - lastUpdateTime) / 1000.0
+            // Clamp dt: minimum 0.1s prevents freeze on same-timestamp events,
+            // maximum 5s caps large gaps (e.g. after pause)
+            val dt = rawDt.coerceIn(0.1, 5.0)
 
-        // Allow negative — that's the model's signal that W'max is calibrated too low.
-        // Cap above at wMax (can't exceed the model's max capacity) and floor at -wMax
-        // (sanity bound — a stuck-high sensor can't drift to absurd negatives).
-        wBalance = (wBalance + dW).coerceIn(-wMax, wMax)
+            val dW = if (power > cp) {
+                (recovery - (power - cp)) * dt
+            } else {
+                recovery * dt
+            }
+
+            // Allow negative — that's the model's signal that W'max is calibrated too low.
+            // Cap above at wMax (can't exceed the model's max capacity) and floor at -wMax
+            // (sanity bound — a stuck-high sensor can't drift to absurd negatives).
+            wBalance = (wBalance + dW).coerceIn(-wMax, wMax)
+        }
+        lastUpdateTime = now
 
         val pct = wBalance / wMax * 100.0
         val depletionRate = if (power > cp) (power - cp) else 0.0
@@ -134,7 +141,9 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             status = WPrimeState.statusForPercentage(pct)
         )
 
-        // Append to history ring buffer + publish updated list
+        // Append to history every tick where sensor data is flowing — including
+        // coasting, including the very first tick (baseline). Drives the W'
+        // history chart's continuous live view across the entire ride.
         recordHistorySample(now, wBalance, pct, state.power)
     }
 

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -55,6 +55,18 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
          *  drifts; the field is consumed at a glance, so a 5 s refresh cadence
          *  reads as "stable" rather than "counting". */
         private const val HORIZON_PUBLISH_INTERVAL_MS = 5_000L
+        /** Settle delay after the horizon direction changes (emptying ↔
+         *  filling). Right at a switch the 30 s power window still holds the
+         *  prior regime's samples, so the projection spikes to the 1 h cap
+         *  before the new effort registers. Withholding the number for 5 s
+         *  lets the window fill, so the value shown is real, not the cap
+         *  artifact. During the settle the field shows the direction symbol
+         *  with a "--" placeholder (no layout jump). Parameter-free — no
+         *  athlete-specific tuning. */
+        private const val HORIZON_SETTLE_MS = 5_000L
+        /** Sentinel in published TTE/TTF: 0 = "this direction, still settling"
+         *  (render symbol + "--"); -1 = not this direction; >0 = settled value. */
+        const val HORIZON_SETTLING = 0L
     }
 
     private val _state = MutableStateFlow(WPrimeState())
@@ -95,6 +107,11 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
     private var publishedTimeToEmpty: Long = -1L
     private var publishedTimeToFull: Long = -1L
     private var lastHorizonPublishMs: Long = 0L
+
+    // Horizon-direction tracking for the settle delay.
+    private enum class HorizonDir { NONE, EMPTYING, FILLING }
+    private var horizonDir: HorizonDir = HorizonDir.NONE
+    private var horizonDirSinceMs: Long = 0L
 
     /**
      * True while the Karoo ride is in [io.hammerhead.karooext.models.RideState.Paused].
@@ -213,12 +230,41 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
             roundTo5(((wMax - wBalance) / smoothedRecovery).toLong().coerceAtMost(3600L))
         } else -1L
 
-        // Hold the published horizon steady for HORIZON_PUBLISH_INTERVAL_MS,
-        // then refresh — so the field updates on a ~5 s cadence, not 1 Hz.
-        if (lastHorizonPublishMs == 0L || now - lastHorizonPublishMs >= HORIZON_PUBLISH_INTERVAL_MS) {
-            publishedTimeToEmpty = computedTimeToEmpty
-            publishedTimeToFull = computedTimeToFull
-            lastHorizonPublishMs = now
+        // Determine the current horizon direction and track when it last
+        // changed. A direction change resets the settle clock + the publish
+        // hold so the new direction re-settles before showing a number.
+        val currentDir = when {
+            computedTimeToEmpty > 0 -> HorizonDir.EMPTYING
+            computedTimeToFull > 0 -> HorizonDir.FILLING
+            else -> HorizonDir.NONE
+        }
+        if (currentDir != horizonDir) {
+            horizonDir = currentDir
+            horizonDirSinceMs = now
+            lastHorizonPublishMs = 0L
+        }
+        val settled = currentDir != HorizonDir.NONE &&
+            now - horizonDirSinceMs >= HORIZON_SETTLE_MS
+
+        when {
+            currentDir == HorizonDir.NONE -> {
+                publishedTimeToEmpty = -1L
+                publishedTimeToFull = -1L
+            }
+            !settled -> {
+                // Settling: expose the direction (so the symbol + "--"
+                // placeholder shows, no layout jump) but withhold the number.
+                publishedTimeToEmpty = if (currentDir == HorizonDir.EMPTYING) HORIZON_SETTLING else -1L
+                publishedTimeToFull = if (currentDir == HorizonDir.FILLING) HORIZON_SETTLING else -1L
+            }
+            else -> {
+                // Settled: refresh the real value on the 5 s hold cadence.
+                if (lastHorizonPublishMs == 0L || now - lastHorizonPublishMs >= HORIZON_PUBLISH_INTERVAL_MS) {
+                    publishedTimeToEmpty = if (currentDir == HorizonDir.EMPTYING) computedTimeToEmpty else -1L
+                    publishedTimeToFull = if (currentDir == HorizonDir.FILLING) computedTimeToFull else -1L
+                    lastHorizonPublishMs = now
+                }
+            }
         }
 
         _state.value = WPrimeState(
@@ -358,6 +404,8 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         publishedTimeToEmpty = -1L
         publishedTimeToFull = -1L
         lastHorizonPublishMs = 0L
+        horizonDir = HorizonDir.NONE
+        horizonDirSinceMs = 0L
         historyBuffer.clear()
         _wPrimeHistory.value = emptyList()
         _state.value = WPrimeState(balance = wMax, maxBalance = wMax)

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -43,13 +43,18 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         private const val DT = 1.0    // 1 second update interval
         /** Ring-buffer cap for per-tick history. 86400 = 24h at 1Hz, ~2.8 MB. */
         const val MAX_HISTORY_SAMPLES = 86400
-        /** Rolling-window length for the smoothed power that drives the
-         *  TTE/TTF projections. Power fluctuates around CP every second on
-         *  real rides, so a per-tick projection flips between depletion and
-         *  recovery branches as noise; a 30 s mean reframes the question as
-         *  "at the rider's current sustained effort" which is what's
-         *  actionable for pacing. */
-        private const val TTE_TTF_SMOOTH_WINDOW_MS = 30_000L
+        /** Trailing window over which the W'-balance trend is measured to
+         *  drive the TTE/TTF horizon. Direction + rate both come from the
+         *  *observed* balance slope over this window — not from smoothed
+         *  power, which lagged badly (a window full of pre-effort low power
+         *  claimed "recovering" while the balance was visibly falling). The
+         *  balance is the integral of (power − CP), so its slope is already
+         *  the right, naturally-smooth quantity. */
+        private const val TREND_WINDOW_MS = 30_000L
+        /** Deadband (J/s) on the balance slope — below this the rider is
+         *  holding steady; no horizon is shown. Avoids a flickery TTE/TTF
+         *  when W' is essentially flat. */
+        private const val TREND_DEADBAND_JPS = 3.0
         /** Hold the published TTE/TTF horizon steady for this long, then
          *  refresh. Even with 30 s-smoothed inputs the second-by-second value
          *  drifts; the field is consumed at a glance, so a 5 s refresh cadence
@@ -99,9 +104,10 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
     private var sumPowerBelowCp: Double = 0.0
     private var countPowerBelowCp: Long = 0L
 
-    /** Rolling 30 s power window for TTE/TTF smoothing. Holds (timestampMs,
-     *  power) pairs trimmed every update() to entries within the window. */
-    private val recentPowerWindow = ArrayDeque<Pair<Long, Int>>()
+    /** Trailing window of (timestampMs, wBalance) used to measure the W'
+     *  trend that drives the TTE/TTF horizon. Trimmed every update() to
+     *  TREND_WINDOW_MS. */
+    private val recentBalanceWindow = ArrayDeque<Pair<Long, Double>>()
 
     // Published (held) TTE/TTF horizons — refreshed at most every
     // HORIZON_PUBLISH_INTERVAL_MS so the displayed countdown holds steady
@@ -204,32 +210,29 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         val depletionRate = if (power > cp) (power - cp) else 0.0
         val recoveryRateVal = if (power <= cp) recovery else 0.0
 
-        // Maintain the rolling power window (TTE/TTF smoothing). Trim entries
-        // older than the window from the front; append the current sample.
-        recentPowerWindow.addLast(now to state.power)
-        while (recentPowerWindow.isNotEmpty() &&
-               now - recentPowerWindow.first().first > TTE_TTF_SMOOTH_WINDOW_MS) {
-            recentPowerWindow.removeFirst()
+        // Maintain the balance-trend window, then derive direction + rate from
+        // the observed slope of W'balance over the window. This is the same
+        // quantity the rider watches move (the % going up or down), so the
+        // horizon can never contradict the visible trend — the prior
+        // smoothed-power approach could (and did, at ride start).
+        recentBalanceWindow.addLast(now to wBalance)
+        while (recentBalanceWindow.isNotEmpty() &&
+               now - recentBalanceWindow.first().first > TREND_WINDOW_MS) {
+            recentBalanceWindow.removeFirst()
         }
-        val smoothedPower =
-            if (recentPowerWindow.isEmpty()) power
-            else recentPowerWindow.map { it.second.toDouble() }.average()
+        val (oldTs, oldBalance) = recentBalanceWindow.first()
+        val spanSeconds = (now - oldTs) / 1000.0
+        // J/s: negative = depleting (heading to empty), positive = recovering.
+        val trendRate = if (spanSeconds >= 1.0) (wBalance - oldBalance) / spanSeconds else 0.0
 
-        // Smoothed depletion / recovery used ONLY for the TTE/TTF horizons —
-        // the displayed `depletionRate` / `recoveryRate` and the chart still
-        // track instantaneous values so the rider sees real-time response.
-        val smoothedDepletion = if (smoothedPower > cp) (smoothedPower - cp) else 0.0
-        val smoothedRecovery = if (smoothedPower <= cp) recovery else 0.0
-
-        // timeToEmpty only meaningful when balance is positive and depleting.
-        // Round to the nearest 5 s so the displayed countdown doesn't jitter
-        // by ±1-2 s from rate-window noise — pacing reads on a coarser scale.
-        val computedTimeToEmpty = if (wBalance > 0 && smoothedDepletion > smoothedRecovery && smoothedDepletion > 0) {
-            roundTo5((wBalance / (smoothedDepletion - smoothedRecovery)).toLong().coerceAtMost(3600L))
+        // timeToEmpty / timeToFull from the trend. Rounded to the nearest 5 s
+        // so the countdown reads coarsely, not jittery. Capped at 1 h.
+        val computedTimeToEmpty = if (trendRate < -TREND_DEADBAND_JPS && wBalance > 0) {
+            roundTo5((wBalance / -trendRate).toLong().coerceAtMost(3600L))
         } else -1L
 
-        val computedTimeToFull = if (smoothedRecovery > 0 && wBalance < wMax) {
-            roundTo5(((wMax - wBalance) / smoothedRecovery).toLong().coerceAtMost(3600L))
+        val computedTimeToFull = if (trendRate > TREND_DEADBAND_JPS && wBalance < wMax) {
+            roundTo5(((wMax - wBalance) / trendRate).toLong().coerceAtMost(3600L))
         } else -1L
 
         // Determine the current horizon direction. At full W' the horizon is
@@ -397,7 +400,7 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         lastUpdateTime = 0L
         sumPowerBelowCp = 0.0
         countPowerBelowCp = 0L
-        recentPowerWindow.clear()
+        recentBalanceWindow.clear()
         publishedTimeToEmpty = -1L
         publishedTimeToFull = -1L
         lastHorizonPublishMs = 0L

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/WPrimeEngine.kt
@@ -60,6 +60,16 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
     private var lastUpdateTime: Long = 0L
     private var profileLoaded = false
 
+    /**
+     * True while the Karoo ride is in [io.hammerhead.karooext.models.RideState.Paused].
+     * Set by [RideStateMonitor]. When paused, [update] is short-circuited and the
+     * engine is driven instead by [tickPauseRecovery] at 1 Hz — pause time
+     * accumulates toward W' refill at the same rate as coasting (Skiba P ≤ CP
+     * recovery branch with P = 0).
+     */
+    @Volatile
+    private var pauseActive: Boolean = false
+
     init {
         scope.launch {
             preferencesRepository.athleteProfileFlow.collect { profile ->
@@ -80,8 +90,15 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         }
     }
 
+    fun setPaused(paused: Boolean) {
+        pauseActive = paused
+    }
+
     fun update(state: LiveClimbState) {
         if (!profileLoaded || cp == 0) return
+        // While the ride is paused, the recovery ticker owns the engine —
+        // skip real samples so we don't double-count pause time.
+        if (pauseActive) return
         // Gate ONLY on the presence of sensor data, not on power being non-zero.
         // power == 0 is a legitimate observation (rider coasting, recovery phase) —
         // the Skiba math handles it correctly (recovery branch applies). The prior
@@ -145,6 +162,51 @@ class WPrimeEngine(private val preferencesRepository: PreferencesRepository) {
         // coasting, including the very first tick (baseline). Drives the W'
         // history chart's continuous live view across the entire ride.
         recordHistorySample(now, wBalance, pct, state.power)
+    }
+
+    /**
+     * Apply one second of pure recovery — pause-time accounting.
+     *
+     * Driven by [RideStateMonitor]'s 1 Hz ticker while the Karoo ride is in
+     * Paused state, where no real power samples flow but Skiba's recovery
+     * branch still applies (P = 0 ≤ CP). Pause time accumulates toward
+     * W' refill at the same rate as coasting on the bike.
+     *
+     * Same invariants as [update]: profile-gated, dt clamped, balance kept
+     * in [-wMax, wMax], lastUpdateTime advanced, history sample appended at
+     * power = 0 so the chart shows a continuous curve through pause.
+     */
+    fun tickPauseRecovery(now: Long) {
+        if (!profileLoaded || cp == 0) return
+        if (!pauseActive) return // belt-and-suspenders; only run while paused
+
+        val recovery = (wMax - wBalance) / TAU
+
+        if (lastUpdateTime != 0L) {
+            val rawDt = (now - lastUpdateTime) / 1000.0
+            val dt = rawDt.coerceIn(0.1, 5.0)
+            wBalance = (wBalance + recovery * dt).coerceIn(-wMax, wMax)
+        }
+        lastUpdateTime = now
+
+        val pct = wBalance / wMax * 100.0
+        val recoveryRateVal = (wMax - wBalance) / TAU
+        val timeToFull = if (recoveryRateVal > 0 && wBalance < wMax) {
+            ((wMax - wBalance) / recoveryRateVal).toLong().coerceAtMost(3600L)
+        } else -1L
+
+        _state.value = WPrimeState(
+            balance = wBalance,
+            maxBalance = wMax,
+            percentage = pct,
+            depletionRate = 0.0,
+            recoveryRate = recoveryRateVal,
+            timeToEmpty = -1L,
+            timeToFull = timeToFull,
+            status = WPrimeState.statusForPercentage(pct)
+        )
+
+        recordHistorySample(now, wBalance, pct, power = 0)
     }
 
     private fun recordHistorySample(

--- a/app/src/main/kotlin/io/github/climbintelligence/ui/screens/AthleteScreen.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/ui/screens/AthleteScreen.kt
@@ -25,13 +25,15 @@ fun AthleteScreen(onNavigateBack: () -> Unit) {
         onNavigateBack = onNavigateBack
     ) {
         ToggleRow(
-            label = stringResource(R.string.settings_use_karoo_ftp),
-            enabled = profile.useKarooFtp,
-            onToggle = { scope.launch { prefs?.updateUseKarooFtp(it) } }
+            label = stringResource(R.string.settings_use_karoo_profile),
+            enabled = profile.useKarooProfile,
+            onToggle = { scope.launch { prefs?.updateUseKarooProfile(it) } }
         )
-        HintText(stringResource(R.string.settings_use_karoo_ftp_hint))
+        HintText(stringResource(R.string.settings_use_karoo_profile_hint))
 
-        if (profile.useKarooFtp && profile.karooFtp > 0) {
+        // FTP row — read-only when toggle is on AND Karoo has a value;
+        // editable otherwise. Same pattern for weight below.
+        if (profile.useKarooProfile && profile.karooFtp > 0) {
             InfoRow(
                 label = stringResource(R.string.settings_karoo_ftp),
                 value = "${profile.karooFtp} W"
@@ -46,12 +48,19 @@ fun AthleteScreen(onNavigateBack: () -> Unit) {
             HintText(stringResource(R.string.settings_ftp_hint))
         }
 
-        DecimalRow(
-            label = stringResource(R.string.settings_weight),
-            value = profile.weight,
-            unit = "kg",
-            onValueChange = { scope.launch { prefs?.updateWeight(it) } }
-        )
+        if (profile.useKarooProfile && profile.karooWeight > 0.0) {
+            InfoRow(
+                label = stringResource(R.string.settings_karoo_weight),
+                value = "%.1f kg".format(profile.karooWeight)
+            )
+        } else {
+            DecimalRow(
+                label = stringResource(R.string.settings_weight),
+                value = profile.weight,
+                unit = "kg",
+                onValueChange = { scope.launch { prefs?.updateWeight(it) } }
+            )
+        }
 
         // Advanced (W', CP)
         SectionHeader(stringResource(R.string.settings_advanced))

--- a/app/src/main/kotlin/io/github/climbintelligence/ui/screens/AthleteScreen.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/ui/screens/AthleteScreen.kt
@@ -24,13 +24,27 @@ fun AthleteScreen(onNavigateBack: () -> Unit) {
         title = stringResource(R.string.settings_athlete),
         onNavigateBack = onNavigateBack
     ) {
-        NumericRow(
-            label = stringResource(R.string.settings_ftp),
-            value = profile.ftp,
-            unit = "W",
-            onValueChange = { scope.launch { prefs?.updateFtp(it) } }
+        ToggleRow(
+            label = stringResource(R.string.settings_use_karoo_ftp),
+            enabled = profile.useKarooFtp,
+            onToggle = { scope.launch { prefs?.updateUseKarooFtp(it) } }
         )
-        HintText(stringResource(R.string.settings_ftp_hint))
+        HintText(stringResource(R.string.settings_use_karoo_ftp_hint))
+
+        if (profile.useKarooFtp && profile.karooFtp > 0) {
+            InfoRow(
+                label = stringResource(R.string.settings_karoo_ftp),
+                value = "${profile.karooFtp} W"
+            )
+        } else {
+            NumericRow(
+                label = stringResource(R.string.settings_ftp),
+                value = profile.ftp,
+                unit = "W",
+                onValueChange = { scope.launch { prefs?.updateFtp(it) } }
+            )
+            HintText(stringResource(R.string.settings_ftp_hint))
+        }
 
         DecimalRow(
             label = stringResource(R.string.settings_weight),
@@ -65,6 +79,21 @@ fun AthleteScreen(onNavigateBack: () -> Unit) {
                     onValueChange = { scope.launch { prefs?.updateCp(it) } }
                 )
                 HintText(stringResource(R.string.settings_cp_hint))
+
+                NumericRow(
+                    label = stringResource(R.string.settings_max_power),
+                    value = profile.maxPower,
+                    unit = "W",
+                    onValueChange = { scope.launch { prefs?.updateMaxPower(it) } }
+                )
+                HintText(stringResource(R.string.settings_max_power_hint))
+
+                ToggleRow(
+                    label = stringResource(R.string.settings_use_three_param_model),
+                    enabled = profile.useThreeParamModel,
+                    onToggle = { scope.launch { prefs?.updateUseThreeParamModel(it) } }
+                )
+                HintText(stringResource(R.string.settings_use_three_param_model_hint))
             }
         }
 

--- a/app/src/main/kotlin/io/github/climbintelligence/ui/screens/MainMenuScreen.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/ui/screens/MainMenuScreen.kt
@@ -50,7 +50,7 @@ fun MainMenuScreen(
 
     // Subtitles
     val athleteSubtitle = if (profile.isConfigured) {
-        "FTP: ${profile.ftp}W \u00B7 ${"%.1f".format(profile.weight)}kg"
+        "FTP: ${profile.effectiveFtp}W \u00B7 ${"%.1f".format(profile.effectiveWeight)}kg"
     } else {
         stringResource(R.string.settings_not_configured)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="alert_wprime_detail_time">Empty in %1$ds — reduce power now</string>
     <string name="alert_wprime_detail_basic">Reduce power — save reserves</string>
     <string name="alert_wprime_empty">W\' depleted — recovery only</string>
+    <string name="alert_wprime_deficit_title">W\' DEFICIT %1$d%%</string>
+    <string name="alert_wprime_deficit_detail">Beyond model — W\'max may be under-tuned</string>
 
     <!-- Alerts: Steep Ahead -->
     <string name="alert_steep_title">%1$s in %2$dm</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,8 @@
     <string name="datatype_match_burn_desc">Above-CP match tracking with recovery timer</string>
     <string name="datatype_next_climb">Next Climb</string>
     <string name="datatype_next_climb_desc">Distance and ETA to next climb on route</string>
+    <string name="datatype_wprime_history">W\' History</string>
+    <string name="datatype_wprime_history_desc">W\' balance chart over the ride — green above zero, purple in deficit (reserve depth)</string>
 
     <!-- Labels -->
     <string name="label_grade">GRADE</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,13 @@
     <string name="settings_bike_weight_hint">Total weight of your bike with accessories</string>
     <string name="settings_cp">CP (Critical Power)</string>
     <string name="settings_cp_hint">Set to 0 for automatic calculation (FTP × 0.95).\nOr enter your tested CP from a 3+12 min protocol.</string>
+    <string name="settings_use_karoo_ftp">Use FTP from Karoo</string>
+    <string name="settings_use_karoo_ftp_hint">Read FTP from the Karoo\'s rider profile instead of entering it here. Recommended — keeps a single source of truth.</string>
+    <string name="settings_karoo_ftp">Karoo FTP</string>
+    <string name="settings_max_power">P-max (1s sprint power)</string>
+    <string name="settings_max_power_hint">Best 1-second sprint power. Used by the Morton 3-parameter model to estimate Maximum Power Available (MPA) given current fatigue. 0 disables.</string>
+    <string name="settings_use_three_param_model">Use 3-parameter model</string>
+    <string name="settings_use_three_param_model_hint">Enables Morton P-max-aware MPA calculation. Needs a configured P-max above.</string>
     <string name="settings_advanced">Advanced</string>
     <string name="settings_advanced_hint">Only change if you know your values from testing</string>
     <string name="settings_wprime">W\' (Anaerobic Capacity)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,9 +134,10 @@
     <string name="settings_bike_weight_hint">Total weight of your bike with accessories</string>
     <string name="settings_cp">CP (Critical Power)</string>
     <string name="settings_cp_hint">Set to 0 for automatic calculation (FTP × 0.95).\nOr enter your tested CP from a 3+12 min protocol.</string>
-    <string name="settings_use_karoo_ftp">Use FTP from Karoo</string>
-    <string name="settings_use_karoo_ftp_hint">Read FTP from the Karoo\'s rider profile instead of entering it here. Recommended — keeps a single source of truth.</string>
+    <string name="settings_use_karoo_profile">Use profile from Karoo</string>
+    <string name="settings_use_karoo_profile_hint">Read FTP and body weight from the Karoo\'s rider profile instead of entering them here. Recommended — keeps a single source of truth.</string>
     <string name="settings_karoo_ftp">Karoo FTP</string>
+    <string name="settings_karoo_weight">Karoo Weight</string>
     <string name="settings_max_power">P-max (1s sprint power)</string>
     <string name="settings_max_power_hint">Best 1-second sprint power. Used by the Morton 3-parameter model to estimate Maximum Power Available (MPA) given current fatigue. 0 disables.</string>
     <string name="settings_use_three_param_model">Use 3-parameter model</string>

--- a/app/src/main/res/xml/extension_info.xml
+++ b/app/src/main/res/xml/extension_info.xml
@@ -118,6 +118,14 @@
         graphical="true"
         icon="@drawable/ic_climb" />
 
+    <!-- W' balance over-time chart -->
+    <DataType
+        typeId="wprime-history"
+        description="@string/datatype_wprime_history_desc"
+        displayName="@string/datatype_wprime_history"
+        graphical="true"
+        icon="@drawable/ic_climb" />
+
     <!-- Bonus Actions (hardware button actions) -->
     <BonusAction
         actionId="toggle-view"


### PR DESCRIPTION
Adds a W'-balance history chart data field plus a set of W'-engine model improvements. Built and ride-tested on a Karoo 3 (via FIT replay) across many iterations.

## W' history chart (new `wprime-history` data field)
- W' balance trace over the ride, drawn as an off-screen Canvas bitmap wrapped in a Glance Image (Glance primitives can't draw smooth curves). Green above the zero baseline, purple below.
- **DEFICIT** state: balance may go negative — when sustained power exceeds CP long enough the Skiba math predicts depletion past zero, which is the model signalling W'max is calibrated too low. Surfaced as a purple 'reserve depth' region rather than clamped at 0.
- Adapts across Glance field sizes (sparkline / mini / full dual-axis / vertical). Full size: kJ left axis, % right axis, big current-% overlay, time axis.
- Rendered at 3x then downscaled so text/lines stay crisp at the Karoo's DPI.
- Y-axis floor at 0 unless the ride actually went into deficit.

## W' engine improvements
- **Recovery during ride pause** — RideState.Paused stops the data stream and used to freeze the model; a 1 Hz ticker now applies the Skiba recovery branch during pause so pause time accumulates toward refill like coasting.
- **Dynamic τ** — replaces the fixed 546 s constant with `546·exp(-0.01·(CP - avgPowerBelowCP)) + 316`.
- **Morton 3-parameter model (optional)** — adds Pmax to the athlete profile + Maximum Power Available `MPA = Pmax - (Pmax - CP)·((W'max - W'bal)/W'max)²`. Off by default.
- **Read FTP + weight from the Karoo rider profile** — 'Use profile from Karoo' toggle (default on) reads UserProfile so the rider doesn't maintain those twice.

## W' Balance field — TTE/TTF
- Time-to-empty / time-to-full direction + rate derive from the observed W'balance slope (not instantaneous power), so the horizon never contradicts the % on screen.
- ▼ (red, depleting) / ▲ (green, recovering), held on a ~5 s cadence with a settle on direction changes, hidden at full W'.

## Notes
- Granular commit history captures the on-device iteration — happy to squash, or squash-merge works.
- Validated end-to-end with [karoo-ride-replay](https://github.com/lgangitano/karoo-ride-replay).