### PR TITLE
Bump karoo-ext 1.1.7 → 1.1.8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,7 +54,7 @@ android {
 
 dependencies {
     // Karoo Extension SDK
-    implementation("io.hammerhead:karoo-ext:1.1.7")
+    implementation("io.hammerhead:karoo-ext:1.1.8")
 
     // Kotlin
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")


### PR DESCRIPTION
Bumps the Karoo Extension SDK from 1.1.7 to 1.1.8.

1.1.8 adds the `DataType.Type.CLIMB` stream (PR #72 upstream, @brentnd) — exposing DISTANCE_TO_TOP / ELEVATION_TO_TOP etc. — which the CLIMBER-integration and W'-chart work build on.

Single-line dependency change; no behavioural change on its own.

(Re-opened as a fresh PR: the previous one — #3 — was auto-closed when I force-pushed this branch during an unrelated commit-author cleanup, which briefly orphaned its history from `main`. The branch is now replanted cleanly on current `main`.)