### PR TITLE
CLIMBER as canonical climb source + GPS route matching

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,7 +54,7 @@ android {
 
 dependencies {
     // Karoo Extension SDK
-    implementation("io.hammerhead:karoo-ext:1.1.7")
+    implementation("io.hammerhead:karoo-ext:1.1.8")
 
     // Kotlin
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,10 @@ dependencies {
     // Karoo Extension SDK
     implementation("io.hammerhead:karoo-ext:1.1.8")
 
+    // Unit tests (JVM, no instrumentation) — climb-detection + stream-mapping logic
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+
     // Kotlin
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")

--- a/app/src/main/kotlin/io/github/climbintelligence/ClimbIntelligenceExtension.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/ClimbIntelligenceExtension.kt
@@ -65,6 +65,19 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
         private const val NOTIFICATION_CHANNEL_ID = "climb_intelligence_bg"
         private const val NOTIFICATION_ID = 2001
 
+        /**
+         * Feature flag for the homegrown ClimbDetector. As of the
+         * `feature/climber-as-canonical-source` PR (karoo-ext 1.1.8+), the
+         * Karoo CLIMB stream is the single source of truth for climb detection
+         * + active climb fields, matching the rider's mental model around
+         * Karoo's CLIMBER (with its own low/medium/high sensitivity setting).
+         *
+         * Set to true ONLY for short-window A/B debugging on the device. A
+         * future cleanup PR (`chore/remove-homegrown-detector`) deletes the
+         * detector class + this flag entirely.
+         */
+        private const val USE_HOMEGROWN_DETECTOR = false
+
         @Volatile
         var instance: ClimbIntelligenceExtension? = null
             private set
@@ -194,7 +207,7 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
                     }
                 }
 
-                // Wire data flow: ClimbDataService -> WPrimeEngine, PacingCalculator, ClimbDetector
+                // Wire data flow: ClimbDataService -> WPrimeEngine, PacingCalculator, (legacy ClimbDetector)
                 connectionJobs += serviceScope.launch {
                     climbDataService.liveState.collect { state ->
                         _wPrimeEngine?.update(state)
@@ -205,37 +218,47 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
                         _pacingCalculator?.wPrimePercent = _wPrimeEngine?.state?.value?.percentage ?: 100.0
                         val currentClimb = _climbDataService?.activeClimb?.value
                         _pacingCalculator?.update(state, currentClimb)
-                        _climbDetector?.update(state)
+                        if (USE_HOMEGROWN_DETECTOR) {
+                            _climbDetector?.update(state)
+                        }
                         _climbStatsTracker?.update(state, currentClimb)
                     }
                 }
 
-                // Wire ClimbDetector → "Climb Started" alert
-                connectionJobs += serviceScope.launch {
-                    var wasConfirmed = false
-                    climbDetector.detectionState.collect { state ->
-                        if (state == ClimbDetector.DetectionState.CONFIRMED_CLIMB && !wasConfirmed) {
-                            wasConfirmed = true
-                            val climb = _climbDetector?.detectedClimb?.value ?: return@collect
-                            _alertManager?.dispatchClimbStarted(
-                                name = climb.name,
-                                lengthKm = climb.distanceClimbedKm,
-                                avgGrade = climb.avgGrade,
-                                elevationM = climb.elevation
-                            )
-                        } else if (state == ClimbDetector.DetectionState.NOT_CLIMBING) {
-                            wasConfirmed = false
+                // Wire ClimbDetector → "Climb Started" alert (LEGACY — disabled when CLIMBER is authoritative)
+                if (USE_HOMEGROWN_DETECTOR) {
+                    connectionJobs += serviceScope.launch {
+                        var wasConfirmed = false
+                        climbDetector.detectionState.collect { state ->
+                            if (state == ClimbDetector.DetectionState.CONFIRMED_CLIMB && !wasConfirmed) {
+                                wasConfirmed = true
+                                val climb = _climbDetector?.detectedClimb?.value ?: return@collect
+                                _alertManager?.dispatchClimbStarted(
+                                    name = climb.name,
+                                    lengthKm = climb.distanceClimbedKm,
+                                    avgGrade = climb.avgGrade,
+                                    elevationM = climb.elevation
+                                )
+                            } else if (state == ClimbDetector.DetectionState.NOT_CLIMBING) {
+                                wasConfirmed = false
+                            }
                         }
                     }
                 }
 
-                // Wire active climb → "Climb Started" + "Summit Approaching" alerts (route climbs)
+                // Wire active climb → "Climb Started" + "Summit Approaching" alerts.
+                // Fires for route climbs (hasRouteMetrics) AND Karoo CLIMB-stream-driven
+                // climbs (length > 0 with distanceToTop > 0). With the homegrown detector
+                // disabled, both surviving paths carry a real total length — the 300m
+                // misleading alert is structurally impossible now.
                 connectionJobs += serviceScope.launch {
                     var climbStartFired = false
                     var summitAlertFired = false
                     var lastClimbId = ""
                     climbDataService.activeClimb.collect { climb ->
-                        if (climb == null || !climb.isActive || !climb.hasRouteMetrics) {
+                        val hasTrustedLength = climb != null && climb.isActive &&
+                            climb.length > 0.0 && climb.distanceToTop > 0.0
+                        if (!hasTrustedLength) {
                             if (climb?.id != lastClimbId) {
                                 climbStartFired = false
                                 summitAlertFired = false
@@ -243,6 +266,8 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
                             }
                             return@collect
                         }
+                        // After the trusted-length check above, climb is non-null
+                        @Suppress("NAME_SHADOWING") val climb = climb!!
                         if (climb.id != lastClimbId) {
                             climbStartFired = false
                             summitAlertFired = false
@@ -253,9 +278,12 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
                             climbStartFired = true
                             _alertManager?.dispatchClimbStarted(
                                 name = climb.name,
-                                lengthKm = climb.length / 1000.0,
+                                // Remaining-from-here, not whole-climb totals — match what
+                                // CLIMBER shows. Detection can lag (you may already be into the
+                                // climb), so the rider needs what's ahead from NOW.
+                                lengthKm = climb.distanceToTop / 1000.0,
                                 avgGrade = climb.avgGrade,
-                                elevationM = climb.elevation
+                                elevationM = climb.elevationToTop
                             )
                         }
                         if (!summitAlertFired && climb.distanceToTop in 50.0..500.0) {
@@ -265,11 +293,13 @@ class ClimbIntelligenceExtension : KarooExtension("climbintelligence", BuildConf
                     }
                 }
 
-                // Wire detected climbs → ClimbDataService.activeClimb (when no route loaded)
-                connectionJobs += serviceScope.launch {
-                    climbDetector.detectedClimb.collect { detected ->
-                        if (!climbDataService.hasRoute.value) {
-                            climbDataService.updateActiveClimb(detected)
+                // Wire detected climbs → ClimbDataService.activeClimb (LEGACY — disabled when CLIMBER is authoritative)
+                if (USE_HOMEGROWN_DETECTOR) {
+                    connectionJobs += serviceScope.launch {
+                        climbDetector.detectedClimb.collect { detected ->
+                            if (!climbDataService.hasRoute.value) {
+                                climbDataService.updateActiveClimb(detected)
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/io/github/climbintelligence/engine/ClimbDataService.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/engine/ClimbDataService.kt
@@ -55,6 +55,9 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
     private val distanceConsumerId = AtomicReference<String?>(null)
     private val locationConsumerId = AtomicReference<String?>(null)
     private val navigationConsumerId = AtomicReference<String?>(null)
+    // Karoo CLIMB stream (karoo-ext 1.1.8+) — native Climber detection on routes + freestyle
+    private val climbStreamConsumerId = AtomicReference<String?>(null)
+    private val climbNumberConsumerId = AtomicReference<String?>(null)
 
     // Current values (thread-safe via AtomicReference)
     private val currentPower = AtomicReference(0)
@@ -66,6 +69,30 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
     private val currentDistance = AtomicReference(0.0)
     private val currentLat = AtomicReference(0.0)
     private val currentLon = AtomicReference(0.0)
+    private val lastLocationMs = AtomicReference(0L)  // wall-clock of the last GPS fix
+
+    // CLIMB stream cached fields (last emitted values)
+    private val currentClimbDistanceToTop = AtomicReference(0.0)
+    private val currentClimbElevationToTop = AtomicReference(0.0)
+    private val currentClimbDistanceFromBottom = AtomicReference(0.0)
+    private val currentClimbElevationFromBottom = AtomicReference(0.0)
+    private val currentClimbElevationTotal = AtomicReference(0.0)
+    private val currentClimbNumber = AtomicReference(0)
+    private val lastClimbStreamEmitMs = AtomicReference(0L)
+    private val climbStreamStartTimestamp = AtomicReference(0L)
+    // Last tick while the CLIMB stream was active — lets us tell a brief stream blip on
+    // the SAME climb from a genuinely new climb when the stream re-activates.
+    private val lastClimbActiveMs = AtomicReference(0L)
+    private val lastClimbDistFromBottom = AtomicReference(0.0)
+    // Previous CLIMB emit's identity/geometry — to detect the stale carry-over tick at a
+    // climb switch (Karoo bumps climbNum before refreshing distance/elevation fields).
+    private val lastEmitClimbNum = AtomicReference(-1)
+    private val lastEmitDistToTop = AtomicReference(-1.0)
+    private val lastEmitDistFromBottom = AtomicReference(-1.0)
+
+    /** True while the Karoo CLIMB stream is emitting on an active climb. */
+    private val _climbStreamActive = MutableStateFlow(false)
+    val climbStreamActive: StateFlow<Boolean> = _climbStreamActive.asStateFlow()
 
     @Volatile
     private var hasReceivedData = false
@@ -80,6 +107,31 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
     // Cached route elevation profile points
     @Volatile
     private var routeElevationPoints: List<ElevationPolylineDecoder.ElevationPoint> = emptyList()
+
+    // Cached route coordinate geometry (lat/lng + cumulative distance) for mapping
+    // a live GPS fix to a distance-along-route, independent of ride distance.
+    @Volatile
+    private var routeGeometry: List<ElevationPolylineDecoder.RoutePoint> = emptyList()
+
+    // Last good distance-along-route (m). Held when the GPS fix is stale so we never
+    // blend route-frame with ride-frame distance, and seeds the continuity window.
+    private val lastRouteDistance = AtomicReference(0.0)
+
+    // A GPS fix older than this is treated as "no fix" (hold last route distance).
+    private val gpsFixMaxAgeMs = 5_000L
+    // A CLIMB-stream re-activation with distanceFromBottom still continuing (not reset toward
+    // a new base) is the SAME climb session — no re-alert. distanceFromBottom continuity is
+    // the real discriminator; the gap is just a generous staleness bound.
+    private val climbSessionContinuationGapMs = 300_000L
+    private val climbSessionContinuationTolM = 200.0
+
+    // routePolyline hash of the currently-latched route. Karoo re-emits NavigatingRoute
+    // for the same route while progressively pruning the climb you're on and re-basing the
+    // rest to your position; the polyline stays identical. We latch the full climb list on
+    // the first populated emit and only rebuild when this signature changes (a real route
+    // change) or on Idle. 0 = nothing latched.
+    @Volatile
+    private var loadedRouteSignature: Int = 0
 
     fun startStreaming() {
         android.util.Log.i(TAG, "Starting data stream subscriptions")
@@ -201,9 +253,106 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
                     val state = event.state
                     if (state is StreamState.Streaming) {
                         val values = state.dataPoint.values
-                        values["lat"]?.let { currentLat.set(it) }
-                        values["lng"]?.let { currentLon.set(it) }
+                        values[DataType.Field.LOC_LATITUDE]?.let { currentLat.set(it) }
+                        values[DataType.Field.LOC_LONGITUDE]?.let { currentLon.set(it) }
+                        lastLocationMs.set(System.currentTimeMillis())
                         sensorUpdatedSinceLastEmit = true
+                    }
+                }
+            )
+
+            // --- Karoo CLIMB stream (1.1.8+) ---
+            // Compound DataType carrying DISTANCE_FROM_BOTTOM, DISTANCE_TO_TOP,
+            // ELEVATION_FROM_BOTTOM, ELEVATION_TO_TOP, CLIMB_ELEVATION — driven by
+            // Karoo's native Climber detection on routes AND freestyle rides.
+            climbStreamConsumerId.set(
+                climbExtension.karooSystem.addConsumer(
+                    OnStreamState.StartStreaming(DataType.Type.CLIMB)
+                ) { event: OnStreamState ->
+                    val state = event.state
+                    if (state is StreamState.Streaming) {
+                        val values = state.dataPoint.values
+                        values[DataType.Field.DISTANCE_TO_TOP]?.let { currentClimbDistanceToTop.set(it) }
+                        values[DataType.Field.DISTANCE_FROM_BOTTOM]?.let { currentClimbDistanceFromBottom.set(it) }
+                        values[DataType.Field.ELEVATION_TO_TOP]?.let { currentClimbElevationToTop.set(it) }
+                        values[DataType.Field.ELEVATION_FROM_BOTTOM]?.let { currentClimbElevationFromBottom.set(it) }
+                        values[DataType.Field.CLIMB_ELEVATION]?.let { currentClimbElevationTotal.set(it) }
+                        lastClimbStreamEmitMs.set(System.currentTimeMillis())
+
+                        // Stale carry-over guard: at a climb switch Karoo flips climbNum
+                        // BEFORE refreshing distanceToTop/FromBottom, so the first tick of the
+                        // new climb still carries the previous climb's geometry. Acting on it
+                        // alerts the old climb's tail (and fools the continuation check). Skip
+                        // that tick — act only once the geometry refreshes for the new climb.
+                        val emitClimbNum = currentClimbNumber.get()
+                        val emitDToTop = currentClimbDistanceToTop.get()
+                        val emitDFromBot = currentClimbDistanceFromBottom.get()
+                        val staleTransition = emitClimbNum != lastEmitClimbNum.get() &&
+                            emitDToTop == lastEmitDistToTop.get() &&
+                            emitDFromBot == lastEmitDistFromBottom.get()
+                        if (staleTransition) {
+                            return@addConsumer
+                        }
+
+                        val onClimb = currentClimbDistanceToTop.get() > 0.0 ||
+                                      currentClimbDistanceFromBottom.get() > 0.0
+                        val wasActive = _climbStreamActive.value
+                        _climbStreamActive.value = onClimb
+
+                        if (onClimb && !wasActive) {
+                            // Only start a NEW session (→ new climb-started alert) for a
+                            // genuinely new climb. If the stream merely blipped and we're
+                            // still up the SAME climb (distanceFromBottom continues, short
+                            // gap), keep the existing session id so we don't re-alert.
+                            val now = System.currentTimeMillis()
+                            val gapMs = now - lastClimbActiveMs.get()
+                            val dFromBot = currentClimbDistanceFromBottom.get()
+                            val continuation = lastClimbActiveMs.get() > 0L &&
+                                gapMs < climbSessionContinuationGapMs &&
+                                dFromBot >= lastClimbDistFromBottom.get() - climbSessionContinuationTolM
+                            if (continuation) {
+                                android.util.Log.i(
+                                    TAG,
+                                    "CLIMB stream re-activated mid-climb (gap ${gapMs}ms," +
+                                        " dFromBot ${dFromBot.toInt()}m) — continuation, keeping session"
+                                )
+                            } else {
+                                climbStreamStartTimestamp.set(now)
+                                android.util.Log.i(
+                                    TAG,
+                                    "CLIMB stream activated — top in ${currentClimbDistanceToTop.get().toInt()}m" +
+                                        " (${currentClimbElevationToTop.get().toInt()}m elevation)"
+                                )
+                            }
+                        } else if (!onClimb && wasActive) {
+                            android.util.Log.i(TAG, "CLIMB stream ended")
+                        }
+
+                        if (onClimb) {
+                            lastClimbActiveMs.set(System.currentTimeMillis())
+                            lastClimbDistFromBottom.set(currentClimbDistanceFromBottom.get())
+                        }
+
+                        // Record this processed emit so the next switch can detect a stale tick.
+                        lastEmitClimbNum.set(emitClimbNum)
+                        lastEmitDistToTop.set(emitDToTop)
+                        lastEmitDistFromBottom.set(emitDFromBot)
+
+                        updateActiveClimbFromStream()
+                        sensorUpdatedSinceLastEmit = true
+                    }
+                }
+            )
+
+            climbNumberConsumerId.set(
+                climbExtension.karooSystem.addConsumer(
+                    OnStreamState.StartStreaming(DataType.Type.CLIMB_NUMBER)
+                ) { event: OnStreamState ->
+                    val state = event.state
+                    if (state is StreamState.Streaming) {
+                        state.dataPoint.values[DataType.Field.CLIMB_NUMBER]?.toInt()?.let {
+                            currentClimbNumber.set(it)
+                        }
                     }
                 }
             )
@@ -217,6 +366,16 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
         emitJob = CoroutineScope(Dispatchers.Main.immediate).launch {
             while (isActive) {
                 delay(1000)
+                // Watchdog: deactivate CLIMB stream if no emit in the last 5s
+                // (Karoo sometimes stops emitting without an explicit zero-out
+                // when a climb ends; without this the activeClimb would stick).
+                if (_climbStreamActive.value &&
+                    (System.currentTimeMillis() - lastClimbStreamEmitMs.get()) > 5000L
+                ) {
+                    android.util.Log.i(TAG, "CLIMB stream watchdog: no emit in 5s — deactivating")
+                    _climbStreamActive.value = false
+                    updateActiveClimbFromStream()
+                }
                 if (hasReceivedData && sensorUpdatedSinceLastEmit) {
                     sensorUpdatedSinceLastEmit = false
                     emitState()
@@ -233,30 +392,43 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
                 android.util.Log.i(TAG, "Route loaded: ${state.name}, ${state.climbs.size} climbs")
                 _hasRoute.value = true
 
-                // Decode elevation polyline for segment analysis
-                routeElevationPoints = state.routeElevationPolyline?.let { polyline ->
-                    when (val result = ElevationPolylineDecoder.decodeSafe(polyline)) {
-                        is ElevationPolylineDecoder.DecodeResult.Success -> {
-                            android.util.Log.i(TAG, "Decoded ${result.points.size} elevation points")
-                            ElevationPolylineDecoder.smooth(result.points)
+                // Only (re)decode geometry + reset the latched climb list when the route
+                // genuinely changes — keyed on the routePolyline. Karoo re-emits the same
+                // route repeatedly while pruning the active climb; the polyline is stable.
+                val signature = state.routePolyline.hashCode()
+                val isNewRoute = signature != loadedRouteSignature
+                if (isNewRoute) {
+                    loadedRouteSignature = signature
+                    routeElevationPoints = state.routeElevationPolyline?.let { polyline ->
+                        when (val result = ElevationPolylineDecoder.decodeSafe(polyline)) {
+                            is ElevationPolylineDecoder.DecodeResult.Success -> {
+                                android.util.Log.i(TAG, "Decoded ${result.points.size} elevation points")
+                                ElevationPolylineDecoder.smooth(result.points)
+                            }
+                            is ElevationPolylineDecoder.DecodeResult.Error -> {
+                                android.util.Log.w(TAG, "Elevation decode failed: ${result.message}")
+                                emptyList()
+                            }
                         }
-                        is ElevationPolylineDecoder.DecodeResult.Error -> {
-                            android.util.Log.w(TAG, "Elevation decode failed: ${result.message}")
-                            emptyList()
-                        }
-                    }
-                } ?: emptyList()
-
-                // Convert Karoo climbs to our ClimbInfo model
-                val climbs = state.climbs.mapIndexed { index, karooClimb ->
-                    buildClimbInfo(index, karooClimb)
+                    } ?: emptyList()
+                    routeGeometry = ElevationPolylineDecoder.buildRouteGeometry(state.routePolyline)
+                    _routeClimbs.value = emptyList()
                 }
-                _routeClimbs.value = climbs
+
+                // Latch the FULL climb list from the first populated emit for this route, and
+                // keep it: Karoo later drops the climb you're on and re-bases the rest to your
+                // position, which would otherwise make the active climb un-matchable mid-ascent.
+                if (_routeClimbs.value.isEmpty() && state.climbs.isNotEmpty()) {
+                    _routeClimbs.value = state.climbs.mapIndexed { index, karooClimb ->
+                        buildClimbInfo(index, karooClimb)
+                    }
+                }
+
 
                 // Set first upcoming climb as active if none is set
-                if (_activeClimb.value == null && climbs.isNotEmpty()) {
-                    val dist = currentDistance.get()
-                    val upcoming = climbs.firstOrNull { dist < it.startDistance + it.length }
+                if (_activeClimb.value == null && _routeClimbs.value.isNotEmpty()) {
+                    val dist = currentRouteDistance()
+                    val upcoming = _routeClimbs.value.firstOrNull { dist < it.startDistance + it.length }
                     if (upcoming != null) {
                         _activeClimb.value = upcoming.copy(isActive = false)
                     }
@@ -273,6 +445,8 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
                     }
                 } ?: emptyList()
 
+                routeGeometry = ElevationPolylineDecoder.buildRouteGeometry(state.polyline)
+
                 val climbs = state.climbs.mapIndexed { index, karooClimb ->
                     buildClimbInfo(index, karooClimb)
                 }
@@ -284,6 +458,8 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
                 _hasRoute.value = false
                 _routeClimbs.value = emptyList()
                 routeElevationPoints = emptyList()
+                routeGeometry = emptyList()
+                loadedRouteSignature = 0  // route unloaded — next load rebuilds + re-latches
                 // Don't clear activeClimb — ClimbDetector may provide detected climbs
             }
         }
@@ -361,13 +537,50 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
 
     /**
      * Called on every distance update — checks if rider is on a route climb
-     * and updates activeClimb with live progress metrics.
+     * and updates activeClimb with live progress metrics. When the Karoo CLIMB
+     * stream is firing (karoo-ext 1.1.8+), it owns activeClimb's progress fields
+     * and this method skips that write; the nextClimb countdown stays computed
+     * here from route position regardless of stream state.
      */
+    /**
+     * Rider's current distance along the loaded route (m), derived from the GPS
+     * fix so it is independent of ride/recording distance — which desyncs when a
+     * route is added mid-ride or the rider joins partway.
+     *
+     * Frame safety: with a route loaded we stay in route-distance space. If the GPS
+     * fix is stale we HOLD the last good route-distance rather than blend in ride
+     * distance (a different origin), which would otherwise jump the climb state by
+     * kilometres. With no route loaded there are no route climbs to match, so ride
+     * distance is the harmless legacy default.
+     */
+    private fun currentRouteDistance(): Double {
+        if (routeGeometry.isEmpty()) return currentDistance.get()
+
+        val lat = currentLat.get()
+        val lon = currentLon.get()
+        val fixAgeMs = System.currentTimeMillis() - lastLocationMs.get()
+        // No usable fix — stale, or the (0,0) "null island" sentinel Karoo emits before a
+        // GPS lock. Hold the last good route-distance rather than map a bogus point, which
+        // otherwise snaps to an arbitrary far vertex and matches a wrong/phantom climb.
+        if (fixAgeMs > gpsFixMaxAgeMs || (lat == 0.0 && lon == 0.0)) return lastRouteDistance.get()
+
+        val prior = lastRouteDistance.get().takeIf { it > 0.0 }  // continuity hint after first match
+        val matched = ElevationPolylineDecoder.nearestDistanceAlong(routeGeometry, lat, lon, prior)
+        val offRoute = matched == null
+        // Off-route (GPS farther than maxSnapM from the route) → hold the last good
+        // route-distance, don't corrupt it with a far snap. We re-acquire (global nearest)
+        // automatically once back within range.
+        if (matched != null) lastRouteDistance.set(matched)
+        val routeDist = lastRouteDistance.get()
+        return routeDist
+    }
+
     private fun updateActiveClimbFromRoute() {
         val climbs = _routeClimbs.value
         if (climbs.isEmpty()) return
 
-        val dist = currentDistance.get()
+        val dist = currentRouteDistance()
+        val streamOwnsActiveClimb = _climbStreamActive.value
 
         // Find the climb we're currently on
         val onClimb = climbs.firstOrNull { climb ->
@@ -375,17 +588,13 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
         }
 
         if (onClimb != null) {
-            val distOnClimb = dist - onClimb.startDistance
-            val distToTop = onClimb.length - distOnClimb
-            val progress = (distOnClimb / onClimb.length).coerceIn(0.0, 1.0)
-            val elevToTop = onClimb.elevation * (distToTop / onClimb.length)
-
-            _activeClimb.value = onClimb.copy(
-                distanceToTop = distToTop,
-                elevationToTop = elevToTop,
-                progress = progress,
-                isActive = true
-            )
+            // CLIMBER-led detection: the route path no longer marks a climb active on
+            // its own. CLIMBER (the CLIMB stream) is the sole detector; GPS is used only
+            // to identify WHICH route climb we're on — which updateActiveClimbFromStream
+            // does (matching this same GPS route-distance to a routeClimb) so it can
+            // attach the route's polyline/segments + metadata once CLIMBER has fired.
+            // Activating here would fire the climb-started alert before CLIMBER detects,
+            // then again when it does (the double-alert observed on a mid-climb join).
 
             // While on a climb, look for the next one after this climb
             val nextAfterCurrent = climbs.firstOrNull { it.startDistance > onClimb.startDistance + onClimb.length }
@@ -410,12 +619,14 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
             // Not on a climb — show next upcoming climb (if any)
             val next = climbs.firstOrNull { it.startDistance > dist }
             if (next != null) {
-                _activeClimb.value = next.copy(
-                    distanceToTop = next.length,
-                    elevationToTop = next.elevation,
-                    progress = 0.0,
-                    isActive = false
-                )
+                if (!streamOwnsActiveClimb) {
+                    _activeClimb.value = next.copy(
+                        distanceToTop = next.length,
+                        elevationToTop = next.elevation,
+                        progress = 0.0,
+                        isActive = false
+                    )
+                }
 
                 // Update next climb countdown
                 val distToNext = (next.startDistance - dist).coerceAtLeast(0.0)
@@ -432,12 +643,96 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
                     hasNext = true
                 )
             } else {
-                if (_activeClimb.value?.isFromRoute == true) {
+                if (!streamOwnsActiveClimb && _activeClimb.value?.isFromRoute == true) {
                     // Past all route climbs
                     _activeClimb.value = null
                 }
                 _nextClimb.value = NextClimbInfo()
             }
+        }
+    }
+
+    /**
+     * Build _activeClimb from the Karoo CLIMB stream cached fields. Called from
+     * the CLIMB consumer callback (karoo-ext 1.1.8+). When a route climb is
+     * underfoot, route metadata (name, category, segments) is overlaid with the
+     * stream's authoritative distanceToTop / elevationToTop / progress.
+     * Otherwise a stream-only ClimbInfo is synthesized — no segments means
+     * Layer 2 (route strategy) and Layer 3 (tactical analyzer) won't fire,
+     * but Layer 1 pacing target still works off the median grade.
+     */
+    private fun updateActiveClimbFromStream() {
+        if (!_climbStreamActive.value) {
+            // Stream just deactivated — clear stream-driven climb (route-only
+            // climbs are managed by updateActiveClimbFromRoute).
+            val current = _activeClimb.value
+            if (current != null && !current.isFromRoute) {
+                _activeClimb.value = null
+            }
+            return
+        }
+
+        val distToTop = currentClimbDistanceToTop.get()
+        val distFromBottom = currentClimbDistanceFromBottom.get()
+        val elevToTop = currentClimbElevationToTop.get()
+        val elevFromBottom = currentClimbElevationFromBottom.get()
+        val climbElevationTotal = currentClimbElevationTotal.get()
+        val totalLength = distToTop + distFromBottom
+        // Total ascent = remaining-to-top + done-from-bottom (conserved across the
+        // climb). CLIMB_ELEVATION is NOT total ascent — on-device trace showed it
+        // reads ~237 m and grows with elevFromBottom, while eToTop+eFromBot = ~407 m
+        // matched Karoo's own Climber drawer. So we do not use CLIMB_ELEVATION here.
+        val totalElevation = elevToTop + elevFromBottom
+        val progress = if (totalLength > 0.0)
+            (distFromBottom / totalLength).coerceIn(0.0, 1.0) else 0.0
+        val avgGrade = if (totalLength > 0.0)
+            (totalElevation / totalLength) * 100.0 else 0.0
+
+        val dist = currentRouteDistance()
+        val routeClimb = _routeClimbs.value.firstOrNull { rc ->
+            dist >= rc.startDistance && dist < (rc.startDistance + rc.length)
+        }
+
+        _activeClimb.value = if (routeClimb != null) {
+            // Route climb metadata + stream's authoritative progress AND totals.
+            // The CLIMB_ELEVATION-derived totalElevation is ground truth; the route
+            // summary's NavigationState.Climb.totalElevation can be badly understated
+            // (e.g. 300 m on a ~1200 m climb), which previously leaked a wrong
+            // elevation into the climb-started alert. Override length/elevation too.
+            routeClimb.copy(
+                length = totalLength,
+                elevation = totalElevation,
+                distanceToTop = distToTop,
+                elevationToTop = elevToTop,
+                progress = progress,
+                isActive = true
+            )
+        } else {
+            // No route — synthesize from stream alone (no segments / category)
+            val startTs = climbStreamStartTimestamp.get()
+                .takeIf { it > 0 } ?: System.currentTimeMillis()
+            val lengthKm = "%.1f km".format(totalLength / 1000.0)
+            ClimbInfo(
+                // Id keyed on the stream-session start (startTs), NOT climbNum: Karoo flips
+                // climbNum at onset and re-detects within one continuous CLIMBER session
+                // (e.g. a 1.1 km climb growing into an 8 km one). The climb-started alert
+                // gate keys on id, so a session-stable id => one alert per session. A real
+                // new session (stream re-activates) gets a fresh startTs and re-alerts.
+                id = "karoo_climb_${startTs}",
+                name = "Climb ($lengthKm)",
+                category = 0,
+                length = totalLength,
+                elevation = totalElevation,
+                avgGrade = avgGrade,
+                maxGrade = avgGrade,
+                segments = emptyList(),
+                distanceToTop = distToTop,
+                elevationToTop = elevToTop,
+                progress = progress,
+                isActive = true,
+                isFromRoute = false,
+                startTimestamp = startTs
+            )
         }
     }
 
@@ -492,6 +787,9 @@ class ClimbDataService(private val climbExtension: ClimbIntelligenceExtension) {
         removeConsumer(distanceConsumerId)
         removeConsumer(locationConsumerId)
         removeConsumer(navigationConsumerId)
+        removeConsumer(climbStreamConsumerId)
+        removeConsumer(climbNumberConsumerId)
+        _climbStreamActive.value = false
     }
 
     private fun removeConsumer(ref: AtomicReference<String?>) {

--- a/app/src/main/kotlin/io/github/climbintelligence/util/ElevationPolylineDecoder.kt
+++ b/app/src/main/kotlin/io/github/climbintelligence/util/ElevationPolylineDecoder.kt
@@ -1,6 +1,11 @@
 package io.github.climbintelligence.util
 
 import android.util.Log
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
 
 /**
  * Decodes Google Encoded Polyline format for elevation profile data.
@@ -233,5 +238,144 @@ object ElevationPolylineDecoder {
                 elevation = i * elevStep
             )
         }
+    }
+
+    // ── Route coordinate geometry (GPS → distance-along-route) ───────────────
+
+    /** A point on the route line with its cumulative distance from route start. */
+    data class RoutePoint(
+        val lat: Double,
+        val lng: Double,
+        val distanceAlongRoute: Double  // meters from route start
+    )
+
+    /**
+     * Decode a Google-encoded lat/lng polyline (precision 5 — `routePolyline` in
+     * NavigationState) into route points carrying cumulative distance-along-route
+     * (haversine between consecutive vertices).
+     *
+     * Lets us map a live GPS fix to a distance along the loaded route, which is
+     * independent of ride/recording distance — that desyncs when a route is added
+     * mid-ride or the rider joins partway. Returns empty on null/empty/garbage.
+     */
+    fun buildRouteGeometry(encoded: String?): List<RoutePoint> {
+        if (encoded.isNullOrEmpty()) return emptyList()
+        return try {
+            val coords = decodeLatLng(encoded)
+            if (coords.isEmpty()) return emptyList()
+            // Reject garbage (e.g. wrong precision or 32-bit varint wrap) rather
+            // than silently producing nonsense distances downstream.
+            if (coords.any { it.first !in -90.0..90.0 || it.second !in -180.0..180.0 }) {
+                Log.w(TAG, "Route polyline decoded out-of-range coords; ignoring")
+                return emptyList()
+            }
+            val out = ArrayList<RoutePoint>(coords.size)
+            var cumulative = 0.0
+            var prev: Pair<Double, Double>? = null
+            for (c in coords) {
+                prev?.let { cumulative += haversineMeters(it.first, it.second, c.first, c.second) }
+                out.add(RoutePoint(c.first, c.second, cumulative))
+                prev = c
+            }
+            out
+        } catch (e: Exception) {
+            Log.e(TAG, "Route geometry decode failed: ${e.message}")
+            emptyList()
+        }
+    }
+
+    /**
+     * Nearest route vertex to (lat, lon) → its distance-along-route (m), or null
+     * if the geometry is empty. Nearest-vertex (not segment-projection): precision-5
+     * route polylines are dense enough that the vertex distance is accurate to a few
+     * metres, which is well within climb-matching tolerance.
+     *
+     * @param nearDistance when set, only vertices within [windowM] of this
+     *   distance-along-route are considered — a continuity constraint so a looping
+     *   or out-and-back route (where the same coordinate appears twice) cannot snap
+     *   to a different pass. Falls back to a global search when nothing lies in the
+     *   window (a large jump, or the first fix).
+     *
+     * Ranking uses a cos(lat)-scaled planar metric — invalid across the ±180°
+     * antimeridian and degenerate at the poles, both irrelevant for cycling routes.
+     */
+    fun nearestDistanceAlong(
+        geometry: List<RoutePoint>,
+        lat: Double,
+        lon: Double,
+        nearDistance: Double? = null,
+        windowM: Double = 2_000.0,
+        maxSnapM: Double = 50.0
+    ): Double? {
+        if (geometry.isEmpty()) return null
+        // Single pass: track the geographically nearest vertex overall, and the nearest
+        // within the continuity window (if a hint is given). Snap distance is real metres
+        // (haversine) so we can gate on "is the rider actually on the route here?".
+        var windowedBest: RoutePoint? = null
+        var windowedM = Double.MAX_VALUE
+        var globalBest: RoutePoint? = null
+        var globalM = Double.MAX_VALUE
+        for (p in geometry) {
+            val d = haversineMeters(lat, lon, p.lat, p.lng)
+            if (d < globalM) { globalM = d; globalBest = p }
+            if (nearDistance != null &&
+                kotlin.math.abs(p.distanceAlongRoute - nearDistance) <= windowM &&
+                d < windowedM
+            ) {
+                windowedM = d; windowedBest = p
+            }
+        }
+        // Prefer the continuity-windowed vertex ONLY if the rider is genuinely near it.
+        // If it's far, the rider jumped (e.g. left the route and rejoined elsewhere) —
+        // re-acquire from the global nearest instead of staying locked to the old spot.
+        if (windowedBest != null && windowedM <= maxSnapM) return windowedBest.distanceAlongRoute
+        if (globalBest != null && globalM <= maxSnapM) return globalBest.distanceAlongRoute
+        // GPS is farther than maxSnapM from the entire route → off-route.
+        return null
+    }
+
+    /** Decode a Google polyline (precision 5) to (lat, lng) pairs. */
+    private fun decodeLatLng(encoded: String): List<Pair<Double, Double>> {
+        val points = mutableListOf<Pair<Double, Double>>()
+        var index = 0
+        var lat = 0
+        var lng = 0
+
+        while (index < encoded.length) {
+            var shift = 0
+            var result = 0
+            var byte: Int
+
+            do {
+                if (index >= encoded.length) break
+                byte = encoded[index++].code - 63
+                result = result or ((byte and 0x1f) shl shift)
+                shift += 5
+            } while (byte >= 0x20)
+            lat += if (result and 1 != 0) (result shr 1).inv() else result shr 1
+
+            shift = 0
+            result = 0
+            do {
+                if (index >= encoded.length) break
+                byte = encoded[index++].code - 63
+                result = result or ((byte and 0x1f) shl shift)
+                shift += 5
+            } while (byte >= 0x20)
+            lng += if (result and 1 != 0) (result shr 1).inv() else result shr 1
+
+            points.add(Pair(lat / 1e5, lng / 1e5))
+        }
+        return points
+    }
+
+    /** Great-circle distance between two coordinates, in meters. */
+    private fun haversineMeters(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+        val earthRadiusM = 6_371_000.0
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+        val a = sin(dLat / 2).pow(2) +
+            cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) * sin(dLon / 2).pow(2)
+        return earthRadiusM * 2 * atan2(sqrt(a), sqrt(1 - a))
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' عند %1$d%% — ثابت حتى القمة</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">تسلق %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">تسلق %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — هدف %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm ارتفاع</string>
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' på %1$d%% — jævnt til toppen</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">STIGNING %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">STIGNING %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Mål %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm højdemeter</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' bei %1$d%% — gleichmäßig bis oben</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">ANSTIEG %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">ANSTIEG %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Ziel %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm Höhenmeter</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' al %1$d%% — constante hasta arriba</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">SUBIDA %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">SUBIDA %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Objetivo %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm de desnivel</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' à %1$d%% — régulier jusqu\'au sommet</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">MONTÉE %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">MONTÉE %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Cible %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm de dénivelé</string>
 

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' ב-%1$d%% — יציב עד הפסגה</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">טיפוס %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">טיפוס %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — יעד %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm עלייה בגובה</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' al %1$d%% — costante fino in cima</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">SALITA %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">SALITA %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Obiettivo %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm di dislivello</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' %1$d%% — 頂上まで安定して</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">クライム %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">クライム %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — 目標 %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm 獲得標高</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' %1$d%% — 정상까지 꾸준히</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">등반 %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">등반 %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — 목표 %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm 고도 상승</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' op %1$d%% — gelijkmatig naar de top</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">KLIM %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">KLIM %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Doel %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm hoogtemeters</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' na %1$d%% — równo do szczytu</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">PODJAZD %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">PODJAZD %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Cel %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm przewyższenia</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' em %1$d%% — constante até o topo</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">SUBIDA %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">SUBIDA %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Alvo %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm de desnível</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' на %1$d%% — ровно до верха</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">ПОДЪЁМ %1$.1f%% · %2$.1fкм</string>
+    <string name="alert_climb_title">ПОДЪЁМ %1$.1f%% · %2$.2fкм</string>
     <string name="alert_climb_detail_power">+%1$dм — Цель %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dм набор высоты</string>
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' på %1$d%% — jämnt till toppen</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">STIGNING %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">STIGNING %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Mål %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm höjdmeter</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' на %1$d%% — рівно до верху</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">ПІДЙОМ %1$.1f%% · %2$.1fкм</string>
+    <string name="alert_climb_title">ПІДЙОМ %1$.1f%% · %2$.2fкм</string>
     <string name="alert_climb_detail_power">+%1$dм — Ціль %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dм набір висоти</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' %1$d%% — 稳定到顶</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">爬坡 %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">爬坡 %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — 目标 %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm 海拔上升</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,7 +90,7 @@
     <string name="alert_summit_detail_save">W\' at %1$d%% — steady to the top</string>
 
     <!-- Alerts: Climb Started -->
-    <string name="alert_climb_title">CLIMB %1$.1f%% · %2$.1fkm</string>
+    <string name="alert_climb_title">CLIMB %1$.1f%% · %2$.2fkm</string>
     <string name="alert_climb_detail_power">+%1$dm — Target %2$dW</string>
     <string name="alert_climb_detail_basic">+%1$dm elevation</string>
 

--- a/app/src/test/kotlin/io/github/climbintelligence/engine/ClimbDetectorTest.kt
+++ b/app/src/test/kotlin/io/github/climbintelligence/engine/ClimbDetectorTest.kt
@@ -1,0 +1,111 @@
+package io.github.climbintelligence.engine
+
+import io.github.climbintelligence.data.model.LiveClimbState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the homegrown [ClimbDetector].
+ *
+ * These prove the detection *logic* independent of the Karoo device. The
+ * production issue ("a climb is never detected") was traced to a data-feed
+ * gap — `ELEVATION_GRADE` is 0 during a karoo-ride-replay session because
+ * grade isn't a pairable sensor — not to a logic bug. The flat-grade test
+ * below pins that down: with grade 0 the detector correctly does nothing,
+ * so the fix lives in the data feed / a real ride, not here.
+ */
+class ClimbDetectorTest {
+
+    /** Feed a steady climb: 1 Hz samples, 10 m/sample, given grade. */
+    private fun ClimbDetector.rideClimb(
+        samples: Int,
+        gradePct: Double,
+        startDistance: Double = 0.0,
+        startAltitude: Double = 100.0,
+        metersPerSample: Double = 10.0,
+    ): LiveClimbState {
+        var dist = startDistance
+        var alt = startAltitude
+        var last = LiveClimbState()
+        repeat(samples) {
+            dist += metersPerSample
+            alt += metersPerSample * gradePct / 100.0
+            last = LiveClimbState(
+                grade = gradePct,
+                altitude = alt,
+                distance = dist,
+                hasData = true,
+            )
+            update(last)
+        }
+        return last
+    }
+
+    @Test
+    fun `sustained 7 percent grade confirms a climb`() {
+        val detector = ClimbDetector()
+        // 30 samples × 10 m = 300 m climbed at 7% → 21 m gain.
+        // Clears confirmDistance (200 m) and minElevation (15 m).
+        detector.rideClimb(samples = 30, gradePct = 7.0)
+
+        assertEquals(
+            ClimbDetector.DetectionState.CONFIRMED_CLIMB,
+            detector.detectionState.value
+        )
+        val climb = detector.detectedClimb.value
+        assertNotNull("a climb should be detected", climb)
+        assertTrue("climb is active", climb!!.isActive)
+        assertTrue("avg grade is in a sane range", climb.avgGrade in 5.0..9.0)
+        assertTrue("length reflects the ride", climb.length >= 200.0)
+    }
+
+    @Test
+    fun `flat grade never detects a climb (reproduces the replay data-gap)`() {
+        val detector = ClimbDetector()
+        // This is the karoo-ride-replay condition: distance accrues but grade
+        // stays 0 (no ELEVATION_GRADE feed). The detector must stay idle.
+        detector.rideClimb(samples = 60, gradePct = 0.0)
+
+        assertEquals(
+            ClimbDetector.DetectionState.NOT_CLIMBING,
+            detector.detectionState.value
+        )
+        assertNull("no climb without grade", detector.detectedClimb.value)
+    }
+
+    @Test
+    fun `short steep ramp stays potential, not confirmed`() {
+        val detector = ClimbDetector()
+        // 10 samples × 10 m = 100 m — above grade threshold but below the
+        // 200 m confirm distance, so it should reach POTENTIAL but not CONFIRMED.
+        detector.rideClimb(samples = 10, gradePct = 8.0)
+
+        assertEquals(
+            ClimbDetector.DetectionState.POTENTIAL_CLIMB,
+            detector.detectionState.value
+        )
+    }
+
+    @Test
+    fun `grade dropping flat after a climb ends it`() {
+        val detector = ClimbDetector()
+        // Confirm a climb…
+        val top = detector.rideClimb(samples = 30, gradePct = 7.0)
+        assertEquals(
+            ClimbDetector.DetectionState.CONFIRMED_CLIMB,
+            detector.detectionState.value
+        )
+        // …then ride flat past the end-distance (150 m) to close it out.
+        detector.rideClimb(
+            samples = 20, gradePct = 0.0,
+            startDistance = top.distance, startAltitude = top.altitude,
+        )
+        assertEquals(
+            ClimbDetector.DetectionState.NOT_CLIMBING,
+            detector.detectionState.value
+        )
+    }
+}

--- a/app/src/test/kotlin/io/github/climbintelligence/util/ElevationPolylineDecoderTest.kt
+++ b/app/src/test/kotlin/io/github/climbintelligence/util/ElevationPolylineDecoderTest.kt
@@ -1,0 +1,95 @@
+package io.github.climbintelligence.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the route-coordinate geometry used to map a live GPS fix to a
+ * distance-along-route (the GPS-based climb-matching path). The encoded sample
+ * is the canonical Google polyline example:
+ *   "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+ * which decodes to (38.5, -120.2), (40.7, -120.95), (43.252, -126.453).
+ */
+class ElevationPolylineDecoderTest {
+
+    private val sample = "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+
+    @Test
+    fun `buildRouteGeometry decodes precision-5 coords with cumulative distance`() {
+        val geo = ElevationPolylineDecoder.buildRouteGeometry(sample)
+
+        assertEquals(3, geo.size)
+        assertEquals(38.5, geo[0].lat, 1e-4)
+        assertEquals(-120.2, geo[0].lng, 1e-4)
+        assertEquals(40.7, geo[1].lat, 1e-4)
+        assertEquals(-120.95, geo[1].lng, 1e-4)
+        assertEquals(43.252, geo[2].lat, 1e-4)
+        assertEquals(-126.453, geo[2].lng, 1e-4)
+
+        // distance starts at 0 and increases monotonically along the line
+        assertEquals(0.0, geo[0].distanceAlongRoute, 1e-9)
+        assertTrue(geo[1].distanceAlongRoute > 0.0)
+        assertTrue(geo[2].distanceAlongRoute > geo[1].distanceAlongRoute)
+    }
+
+    @Test
+    fun `buildRouteGeometry returns empty on null or blank`() {
+        assertTrue(ElevationPolylineDecoder.buildRouteGeometry(null).isEmpty())
+        assertTrue(ElevationPolylineDecoder.buildRouteGeometry("").isEmpty())
+    }
+
+    @Test
+    fun `nearestDistanceAlong returns the matching vertex distance`() {
+        val geo = ElevationPolylineDecoder.buildRouteGeometry(sample)
+
+        // querying a vertex's own coordinate returns that vertex's distance
+        val atSecond = ElevationPolylineDecoder.nearestDistanceAlong(geo, 40.7, -120.95)
+        assertEquals(geo[1].distanceAlongRoute, atSecond!!, 1e-6)
+
+        // querying the first vertex's coordinate returns ~0
+        val atFirst = ElevationPolylineDecoder.nearestDistanceAlong(geo, 38.5, -120.2)
+        assertEquals(0.0, atFirst!!, 1e-6)
+    }
+
+    @Test
+    fun `nearestDistanceAlong is null on empty geometry`() {
+        assertNull(ElevationPolylineDecoder.nearestDistanceAlong(emptyList(), 1.0, 2.0))
+    }
+
+    @Test
+    fun `buildRouteGeometry handles a single vertex`() {
+        val geo = ElevationPolylineDecoder.buildRouteGeometry("_p~iF~ps|U") // (38.5, -120.2)
+        assertEquals(1, geo.size)
+        assertEquals(0.0, geo[0].distanceAlongRoute, 1e-9)
+        assertEquals(0.0, ElevationPolylineDecoder.nearestDistanceAlong(geo, 38.5, -120.2)!!, 1e-9)
+    }
+
+    @Test
+    fun `nearestDistanceAlong returns null when off-route, re-acquires when back on`() {
+        val geo = ElevationPolylineDecoder.buildRouteGeometry(sample)
+        // The sample's vertices are hundreds of km apart, so a far GPS fix is beyond the
+        // 50 m snap → off-route → null (instead of snapping to an arbitrary far vertex).
+        assertNull(ElevationPolylineDecoder.nearestDistanceAlong(geo, 0.0, 0.0))
+        // A continuity hint does not override the off-route gate.
+        assertNull(ElevationPolylineDecoder.nearestDistanceAlong(geo, 0.0, 0.0, nearDistance = 0.0))
+        // Re-acquire: even with a stale hint at distance 0, a fix exactly on the 3rd vertex
+        // falls back to the global nearest (the windowed candidate is far) and returns it.
+        assertEquals(
+            geo[2].distanceAlongRoute,
+            ElevationPolylineDecoder.nearestDistanceAlong(geo, 43.252, -126.453, nearDistance = 0.0)!!,
+            1e-6
+        )
+    }
+
+    @Test
+    fun `nearestDistanceAlong falls back to global when window is empty`() {
+        val geo = ElevationPolylineDecoder.buildRouteGeometry(sample)
+        // No vertex within 10 m of an absurd nearDistance → global nearest is returned.
+        val r = ElevationPolylineDecoder.nearestDistanceAlong(
+            geo, 43.252, -126.453, nearDistance = 9_999_999.0, windowM = 10.0
+        )
+        assertEquals(geo[2].distanceAlongRoute, r!!, 1e-6)
+    }
+}


### PR DESCRIPTION
## Summary

Adapts 7climb to Karoo's native **CLIMBER** (karoo-ext 1.1.8) and makes it the authoritative climb source, with GPS-based identification of which route climb the rider is on.

Built on #6 (the 1.1.7 → 1.1.8 SDK bump) — please merge that first; until then this PR's diff also contains the bump commit.

## Climb data & detection
- Subscribe to `DataType.Type.CLIMB`; CLIMBER is the sole climb detector (the route/GPS path no longer activates a climb on its own).
- Total ascent = `ELEVATION_TO_TOP + ELEVATION_FROM_BOTTOM`. (`CLIMB_ELEVATION` turned out to be the rider's current altitude ASL, not the climb total.)
- Route climbs: latch the full climb list from the first populated `NavigationState` emit and keep it — Karoo progressively prunes the climb you're on and re-bases the remaining climbs' `startDistance` to your position as you ride.
- Skip the stale carry-over tick at a climb switch (Karoo flips `climbNumber` before refreshing the distance/elevation fields), so each climb is processed with its own data.

## GPS route matching
- Decode the precision-5 `routePolyline` into points carrying cumulative (haversine) distance-along-route; map the live `LOCATION` fix to a route distance — independent of ride/recording distance, which desyncs on a mid-ride route add or a partial join.
- Max-snap gate (50 m): a far continuity candidate triggers a global re-acquire; beyond the route entirely is treated as off-route (hold last). Reads `LOC_LATITUDE` / `LOC_LONGITUDE`.

## Alerts
- Climb-started announces **remaining-to-top** (`distanceToTop` / `elevationToTop`) to match CLIMBER, fires **once per climb session** (id keyed on the session start, with a continuation guard for same-climb stream blips), and shows distance to 2 decimals.

## Testing
- On-device via karoo-ride-replay: correct elevation, GPS-anchored matching, off-route → rejoin re-acquire, and one alert per climb (route and freestyle).
- JVM unit tests for the polyline / route-geometry math and climb detection.

## Scope
- No changes to pacing strategy, FIT recording, Room schema, or the data-field roster — internal data plumbing + alert content only.
